### PR TITLE
fix: OOTB blockers — install-time issues (PR 1/4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,27 +2,52 @@
 # Copy to .env and fill in the values you need.
 
 # ─── Embeddings Provider ───────────────────────────────────────────────────────
-# Options: local (default), openai, deepseek
-# local     — runs all-MiniLM-L6-v2 ONNX model on-device, no API key needed
-# openai    — calls OpenAI embeddings API, requires OPENAI_API_KEY
-# deepseek  — calls DeepSeek embeddings API, requires DEEPSEEK_API_KEY
-# anthropic — NOT SUPPORTED (Anthropic has no embeddings API); falls back to local
-EMBEDDINGS_PROVIDER=local
+# Options: openai (default), deepseek, none
+# openai    — OpenAI text-embedding-3-small (1536 dims). Requires OPENAI_API_KEY.
+# deepseek  — DeepSeek embeddings API (OpenAI-compatible). Requires DEEPSEEK_API_KEY.
+# none      — explicit keyword-only scoring. No semantic matching.
+#             Use this only if you knowingly want to disable embedding-based
+#             interest matching; ranking quality drops significantly.
+# anthropic — NOT SUPPORTED (Anthropic has no embeddings API).
+EMBEDDINGS_PROVIDER=openai
 
 # OpenAI (used when EMBEDDINGS_PROVIDER=openai)
 # OPENAI_API_KEY=sk-...
 # OPENAI_EMBEDDING_MODEL=text-embedding-3-small   # or text-embedding-3-large
 
+# Split-provider env vars: use these to point embeddings at a different host or
+# key than chat. When unset, the generic OPENAI_API_KEY / OPENAI_BASE_URL above
+# are used as fallback so existing configs keep working.
+# OPENAI_EMBEDDINGS_API_KEY=sk-...
+# OPENAI_EMBEDDINGS_BASE_URL=https://api.openai.com/v1
+# OPENAI_EMBEDDINGS_MODEL=text-embedding-3-small
+
 # DeepSeek (used when EMBEDDINGS_PROVIDER=deepseek)
 # DEEPSEEK_API_KEY=sk-...
 # DEEPSEEK_EMBEDDING_MODEL=deepseek-embedding
 
-# ─── LLM for Swarm / WorldSim modes ───────────────────────────────────────────
-# Marble's swarm and worldsim modes accept a user-supplied async LLM function.
-# Pass it via the constructor: new Marble({ llm: async (prompt) => ... })
-# Common choices: Anthropic Claude, OpenAI GPT, local Ollama.
-# ANTHROPIC_API_KEY=sk-ant-...      # if wiring Claude as your LLM
-# OPENAI_API_KEY=sk-...             # also used here if wiring GPT
+# ─── LLM for Swarm / WorldSim / learn() / investigate() ───────────────────────
+# Marble's swarm, worldsim, learn() and investigate() modes accept an LLM
+# client built by core/llm-provider.js::createLLMClient(), or a user-supplied
+# async function passed to the Marble constructor via { llm: ... }.
+#
+# LLM_PROVIDER — "anthropic" (default) | "openai" | "deepseek" | "openai-compatible"
+# LLM_PROVIDER=anthropic
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+# DEEPSEEK_API_KEY=sk-...
+
+# Generic OpenAI-compatible provider (Moonshot/Kimi, Together, Fireworks, Groq,
+# OpenRouter, Azure OpenAI, self-hosted vLLM, etc.). Set LLM_PROVIDER=openai-compatible
+# and fill both of these:
+# LLM_BASE_URL=https://api.moonshot.cn/v1
+# LLM_API_KEY=sk-...
+# MARBLE_LLM_MODEL=kimi-k2                # required — no sensible default
+
+# Self-hosted Ollama via the DeepSeek branch: set this to 1 if DEEPSEEK_BASE_URL
+# points at an Ollama instance that uses /api/chat with x-api-key.
+# DEEPSEEK_IS_OLLAMA=1
+# DEEPSEEK_BASE_URL=https://my-ollama-host/v1
 
 # ─── Source adapters ──────────────────────────────────────────────────────────
 # NEWSAPI_KEY=your-key-here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Install-time blockers (OOTB integration pass 1)
+
+- **`.env.example` no longer misrepresents the default embeddings provider.**
+  The old default `EMBEDDINGS_PROVIDER=local` claimed "no API key needed"
+  but was falling through to `NullEmbeddings` with a single easy-to-miss warning
+  (local ONNX embeddings were removed). Default is now `openai` with an explicit
+  `OPENAI_API_KEY` requirement, and `EMBEDDINGS_PROVIDER=none` is documented as
+  the explicit keyword-only opt-in.
+- **Louder failure when embeddings fail to initialize.** The module-level
+  singleton now emits a prominent one-time boxed warning that names the problem
+  and the fix. Integrators who request `EMBEDDINGS_PROVIDER=none` or pass their
+  own `{ embeddings: ... }` to the constructor see no warning.
+- **`KnowledgeGraph#seedClones` and `#breedStrongClones` no longer crash on
+  malformed LLM output.** Both sites used `text.match(/.../)[0]` which threw
+  `Cannot read properties of null` on empty/prose/truncated completions.
+  Replaced with a tolerant `_extractJSON(text, shape)` helper; failures now log
+  a clear warning and skip the bad response rather than aborting `learn()`.
+- **`max_tokens` raised on both clone prompts.** `seedClones` 1200 → 4096 and
+  `breedStrongClones` 600 → 4096 — the old limits routinely truncated nested
+  JSON responses. Both are now overridable via an `{ maxTokens }` option for
+  providers with lower ceilings.
+- **`embeddings` option on `new Marble()` now threads through to the Scorer.**
+  Previously the constructor accepted `embeddings` but the Scorer imported the
+  module singleton unconditionally — custom providers (for caching, retries,
+  alternative hosts) were silently ignored. Scorer constructor accepts
+  `{ embeddings }` as an option; `new Marble({ embeddings })` wires it through.
+- **Construction-time warnings de-duplicated across instances.** "No LLM
+  provider configured" and "No embeddings configured" warnings now fire at most
+  once per process, not once per `new Marble()`. Batch workloads that spin up
+  one instance per user/request/session no longer flood stderr.
+- **New `silent: true` constructor option** suppresses the above warnings
+  entirely for callers that know what they're doing.
+
 ### BREAKING CHANGES
 
 - **Package renamed**: `marblism` → `marble`

--- a/core/embeddings.js
+++ b/core/embeddings.js
@@ -2,12 +2,13 @@
  * Embeddings for Marble
  *
  * Provides semantic embeddings via API providers.
- * Supported providers: openai (default), deepseek
+ * Supported providers: openai (default), deepseek, none
  *
  * Requires OPENAI_API_KEY (or DEEPSEEK_API_KEY for deepseek provider).
+ * Set EMBEDDINGS_PROVIDER=none to explicitly opt into keyword-only scoring.
  * If the provider cannot be initialised (missing key) or an API call fails at
- * runtime, a NullEmbeddings fallback is used — findMostSimilar() returns no
- * match so callers fall through to their keyword/topic-based fallback paths.
+ * runtime, a NullEmbeddings fallback is used (with a one-time prominent
+ * warning) so callers fall through to their keyword/topic-based fallback paths.
  */
 
 /**
@@ -161,6 +162,10 @@ function createEmbeddingsProvider(options = {}) {
     case 'deepseek':
       return new DeepSeekEmbeddings(options);
 
+    case 'none':
+      // Explicit opt-in to keyword-only scoring. No semantic matching.
+      return new NullEmbeddings();
+
     case 'anthropic':
       throw new Error(
         'Anthropic does not offer an embeddings API. ' +
@@ -170,24 +175,44 @@ function createEmbeddingsProvider(options = {}) {
     case 'local':
       throw new Error(
         'Local ONNX embeddings have been removed from Marble. ' +
-        'Set OPENAI_API_KEY and use EMBEDDINGS_PROVIDER=openai (default).'
+        'Set OPENAI_API_KEY and use EMBEDDINGS_PROVIDER=openai (default), ' +
+        'or use EMBEDDINGS_PROVIDER=none for explicit keyword-only scoring.'
       );
 
     default:
       throw new Error(
-        `Unknown EMBEDDINGS_PROVIDER "${provider}". Supported: "openai", "deepseek".`
+        `Unknown EMBEDDINGS_PROVIDER "${provider}". ` +
+        `Supported: "openai", "deepseek", "none".`
       );
   }
 }
 
 // Export singleton instance (respects EMBEDDINGS_PROVIDER env var).
 // If the provider cannot be initialised (e.g. missing API key) we fall back to
-// NullEmbeddings so the module loads cleanly and callers degrade gracefully.
+// NullEmbeddings so the module loads cleanly, but emit a prominent one-time
+// warning so integrators don't silently lose semantic scoring on the happy path.
+// Callers who want to suppress this should either:
+//   (a) set EMBEDDINGS_PROVIDER=none to explicitly opt into keyword-only, or
+//   (b) pass their own provider to `new Marble({ embeddings: ... })`.
 export const embeddings = (() => {
   try {
     return createEmbeddingsProvider();
   } catch (err) {
-    console.warn(`[embeddings] Provider init failed (${err.message}) — using NullEmbeddings. Embedding-based scoring will be skipped.`);
+    const requestedNone = (process.env.EMBEDDINGS_PROVIDER || '').toLowerCase() === 'none';
+    if (!requestedNone) {
+      const banner =
+        '\n' +
+        '┌─ Marble embeddings ─────────────────────────────────────────┐\n' +
+        '│  Provider init failed — falling back to NullEmbeddings.     │\n' +
+        '│  Semantic scoring is DISABLED; scorer uses keyword only.    │\n' +
+        '│  Fix: set OPENAI_API_KEY (or DEEPSEEK_API_KEY) and a valid  │\n' +
+        '│       EMBEDDINGS_PROVIDER, or pass { embeddings: ... } to   │\n' +
+        '│       the Marble constructor. To silence this warning,      │\n' +
+        '│       set EMBEDDINGS_PROVIDER=none explicitly.              │\n' +
+        `│  Reason: ${err.message.slice(0, 50).padEnd(50)} │\n` +
+        '└─────────────────────────────────────────────────────────────┘';
+      console.warn(banner);
+    }
     return new NullEmbeddings();
   }
 })();

--- a/core/index.js
+++ b/core/index.js
@@ -18,6 +18,12 @@ import { Swarm } from './swarm.js';
 import { Clone } from './clone.js';
 import { decayPass } from './decay.js';
 
+// Module-level flags so missing-provider warnings fire at most once per
+// process, not once per `new Marble()`. Batch workloads (one instance per
+// user/request/session) would otherwise flood stderr with duplicates.
+let _warnedNoLLM = false;
+let _warnedNoEmbeddings = false;
+
 export class Marble {
   /**
    * @param {Object} opts
@@ -29,6 +35,7 @@ export class Marble {
    * @param {boolean}  [opts.arcReorder=false] - Apply narrative arc reranking (newsletter/content curation only)
    * @param {number}   [opts.coldStartThreshold=10] - Signals needed before full personalization
    * @param {number}   [opts.cloneBoostWeight=0.3] - How much clone consensus influences scoring
+   * @param {boolean}  [opts.silent=false] - Suppress construction-time warnings about missing providers
    */
   constructor({
     storage = './marble-kg.json',
@@ -39,9 +46,10 @@ export class Marble {
     arcReorder = false,
     coldStartThreshold = 10,
     cloneBoostWeight = 0.3,
+    silent = false,
   } = {}) {
     this.kg = new KnowledgeGraph(storage);
-    this.scorer = new Scorer(this.kg, { coldStartThreshold });
+    this.scorer = new Scorer(this.kg, { coldStartThreshold, embeddings });
     this.arc = new ArcReranker();
     this.count = count;
     this.mode = mode;
@@ -55,13 +63,17 @@ export class Marble {
     this.clonePopulation = null;
     this.feedbackEngine = null;
 
-    if (!llm) {
+    if (!silent && !llm && !_warnedNoLLM) {
+      _warnedNoLLM = true;
       console.warn('[Marble] No LLM provider configured. Only L0+L1 scoring available. '
-        + 'Pass { llm: yourLLMFunction } for full pipeline (L1.5, L2, L3).');
+        + 'Pass { llm: yourLLMFunction } for full pipeline (L1.5, L2, L3). '
+        + 'Pass { silent: true } to suppress this warning.');
     }
-    if (!embeddings && !process.env.OPENAI_API_KEY) {
+    if (!silent && !embeddings && !process.env.OPENAI_API_KEY && !_warnedNoEmbeddings) {
+      _warnedNoEmbeddings = true;
       console.warn('[Marble] No embeddings configured. Scorer will use keyword matching only. '
-        + 'Set OPENAI_API_KEY or pass { embeddings: provider } for semantic scoring.');
+        + 'Set OPENAI_API_KEY or pass { embeddings: provider } for semantic scoring. '
+        + 'Pass { silent: true } to suppress this warning.');
     }
   }
 

--- a/core/kg.js
+++ b/core/kg.js
@@ -15,6 +15,24 @@ import { readFile, writeFile } from 'fs/promises';
 import { extractEntityAttributes } from './entity-extractor.js';
 import { embeddings as defaultEmbeddings } from './embeddings.js';
 
+/**
+ * Tolerant JSON extraction from LLM text output.
+ *
+ * LLM completions can arrive empty, prose-wrapped, truncated mid-structure, or
+ * otherwise malformed. Callers MUST handle null rather than assuming success.
+ *
+ * @param {string} text
+ * @param {'object'|'array'} [shape='object']
+ * @returns {any|null}
+ */
+function _extractJSON(text, shape = 'object') {
+  if (!text || typeof text !== 'string') return null;
+  const re = shape === 'array' ? /\[[\s\S]*\]/ : /\{[\s\S]*\}/;
+  const m = text.match(re);
+  if (!m) return null;
+  try { return JSON.parse(m[0]); } catch { return null; }
+}
+
 export class KnowledgeGraph {
   constructor(dataPath) {
     this.dataPath = dataPath;
@@ -804,9 +822,16 @@ export class KnowledgeGraph {
    *
    * @param {Object} llm - LLM client from llm-provider.js
    * @param {string} model
+   * @param {Object} [opts]
+   * @param {number} [opts.maxTokens=4096] - LLM max_tokens. Default is generous
+   *   because the prompt asks for nested JSON (arrays of beliefs/preferences/
+   *   identities) and tighter limits truncate mid-structure. Lower only if your
+   *   provider caps below 4096.
    * @returns {Promise<import('./types.js').UserClone[]>}
    */
-  async seedClones(llm, model) {
+  async seedClones(llm, model, opts = {}) {
+    const maxTokens = opts.maxTokens ?? 4096;
+
     // Read gaps stored by CuriosityLoop (beliefs with key starting with gap:)
     const gapBeliefs = (this.user.beliefs || []).filter(b => b.topic?.startsWith('gap:'));
     const gaps = gapBeliefs.map(b => b.claim ?? b.value ?? b.topic.replace('gap:', ''));
@@ -844,11 +869,18 @@ Return ONLY the JSON array. No explanation.`;
 
     const resp = await llm.messages.create({
       model,
-      max_tokens: 1200,
+      max_tokens: maxTokens,
       messages: [{ role: 'user', content: prompt }],
     });
-    const text = resp.content[0].text;
-    const raw = JSON.parse(text.match(/\[[\s\S]*\]/)[0]);
+    const text = resp?.content?.[0]?.text;
+    const raw = _extractJSON(text, 'array');
+    if (!raw || !Array.isArray(raw)) {
+      console.warn(
+        '[kg.seedClones] LLM response did not contain a parseable JSON array — skipping seed. ' +
+        'Check LLM output length/truncation or provider health.'
+      );
+      return [];
+    }
     const now = Date.now();
     return raw.map((h, i) => ({
       id: `clone_seed_${now}_${i}`,
@@ -887,12 +919,23 @@ Return ONLY the JSON array. No explanation.`;
     }
   }
 
-  async breedStrongClones(llm, model) {
+  /**
+   * Breed a neighbouring archetype from every strong clone (confidence > 0.75).
+   *
+   * @param {Object} llm - LLM client from llm-provider.js
+   * @param {string} model
+   * @param {Object} [opts]
+   * @param {number} [opts.maxTokens=4096] - LLM max_tokens per breed call.
+   *   Tighter limits truncate the nested kgOverrides JSON.
+   */
+  async breedStrongClones(llm, model, opts = {}) {
+    const maxTokens = opts.maxTokens ?? 4096;
+
     const strong = this.getActiveClones().filter(c => c.confidence > 0.75);
     for (const parent of strong) {
       const resp = await llm.messages.create({
         model,
-        max_tokens: 600,
+        max_tokens: maxTokens,
         messages: [{
           role: 'user',
           content: `A user archetype hypothesis has proven strong (confidence > 0.75):
@@ -918,7 +961,14 @@ Return JSON:
 Return ONLY the JSON object.`,
         }],
       });
-      const raw = JSON.parse(resp.content[0].text.match(/\{[\s\S]*\}/)[0]);
+      const raw = _extractJSON(resp?.content?.[0]?.text, 'object');
+      if (!raw || typeof raw !== 'object') {
+        console.warn(
+          `[kg.breedStrongClones] LLM response for parent "${parent.id}" did not contain ` +
+          'parseable JSON object — skipping this parent. Check for truncation or prose wrapping.'
+        );
+        continue;
+      }
       this.saveClone({
         id: `clone_bred_${Date.now()}`,
         gap: raw.gap || parent.gap || '',

--- a/core/scorer.js
+++ b/core/scorer.js
@@ -6,7 +6,7 @@
  */
 
 import { SCORE_WEIGHTS, MetricConfiguration, USE_CASE_CONFIGS } from './types.js';
-import { embeddings } from './embeddings.js';
+import { embeddings as defaultEmbeddings } from './embeddings.js';
 import { MetricDrivenScoringEngine } from './enterprise/metric-driven-scoring-engine.js';
 import { swarmScore, generateAgentFleet } from './swarm.js';
 import { globalCollaborativeFilter } from './collaborative-filter.js';
@@ -27,6 +27,12 @@ export class Scorer {
     // Threshold at which Marble stops leaning on popularity prior.
     // Default 10 means sparse profiles quickly shift to personalization signals.
     this.coldStartThreshold = options.coldStartThreshold ?? 10;
+    // Embeddings provider — injectable. Falls back to the module-level
+    // singleton (respects EMBEDDINGS_PROVIDER env var) when no provider is
+    // passed by the caller. Integrators that build custom providers (for
+    // caching, retries, alternative hosts) can pass them here via
+    // `new Marble({ embeddings })`, which threads through to the Scorer.
+    this.embeddings = options.embeddings || defaultEmbeddings;
 
     // Initialize metric-driven scoring engine
     if (this.metricConfig) {
@@ -504,7 +510,7 @@ export class Scorer {
     try {
       // Use semantic matching for preference alignment
       const preferenceTexts = userPreferences.map(p => p.description).filter(Boolean);
-      const bestMatch = await embeddings.findMostSimilar(storyText, preferenceTexts, 0.15);
+      const bestMatch = await this.embeddings.findMostSimilar(storyText, preferenceTexts, 0.15);
 
       if (bestMatch.similarity > 0) {
         const matchedPreference = userPreferences[bestMatch.index];
@@ -724,7 +730,7 @@ export class Scorer {
         .map(interest => typeof interest === 'string' ? interest : interest.name || interest.topic)
         .filter(Boolean);
 
-      const bestMatch = await embeddings.findMostSimilar(storyText, interestTexts, 0.2);
+      const bestMatch = await this.embeddings.findMostSimilar(storyText, interestTexts, 0.2);
 
       if (bestMatch && bestMatch.similarity > 0) {
         const semanticScore = Math.min(1, bestMatch.similarity * 1.2);


### PR DESCRIPTION
## Summary

Fixes five install-time blockers that a downstream integrator hit while trying to use Marble out-of-the-box. All are general-purpose library concerns — none specific to their use case.

- **.env.example** no longer lies about the default embeddings provider (removed `local` as default since ONNX was removed; documented `none` as explicit keyword-only opt-in).
- **Singleton embedding failure** is now a prominent one-time banner (not an easy-to-miss single-line warn); suppressed when `EMBEDDINGS_PROVIDER=none` is requested.
- **`KnowledgeGraph#seedClones` and `#breedStrongClones`** no longer crash on malformed LLM output (`text.match(/.../)[0]` threw on empty / prose / truncated responses). Replaced with a tolerant `_extractJSON` helper; failures log and skip.
- **`max_tokens` raised on both clone prompts** (1200→4096, 600→4096) — old limits routinely truncated nested-JSON responses. Both overridable via `{ maxTokens }`.
- **`embeddings` option on `new Marble()` now threads through to Scorer** instead of being silently ignored. Per-instance "No LLM/embeddings" warnings de-duplicated; `silent: true` suppresses them entirely.

This is PR 1 of 4 planned — covers blockers only. Provider generalization, scorer correctness on topic-thin data, and API surface polish follow in subsequent PRs.

## Test plan

- [x] `npm test` — all 13 tests pass
- [x] `EMBEDDINGS_PROVIDER=none` — module loads NullEmbeddings without emitting the warning banner
- [x] `KnowledgeGraph#seedClones` / `#breedStrongClones` given junk / truncated LLM responses — log clearly and skip instead of throwing
- [x] `new Marble({ embeddings: customProvider })` — `marble.scorer.embeddings === customProvider` (DI verified)
- [x] Construction-time warnings fire once per process, not once per instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)