### PR TITLE
feat: scorer correctness + no-LLM keyword fallback (PR 3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — API surface polish (OOTB integration pass 4)
+
+- **New `Marble#score(items, context)` public method.** Returns every scored
+  item (not sliced to `count`), sorted descending, without arc reordering.
+  Use this for AUC / MRR evaluations, external rerankers, or any case where
+  you need the full ranking distribution. `select()` is now a thin wrapper
+  around `score()` that applies the count slice and optional arc reorder.
+- **`select()` / `score()` return shape is now documented.** Previous JSDoc
+  said only "Top items, arc-ordered". The new `@returns` typedef spells out
+  the wrapper object: `story` (original item, legacy name), `item` (new
+  non-breaking alias), `relevance_score`, `magic_score`, and any
+  per-dimension components. Callers no longer have to dig into
+  `result[0].<??>` by trial and error.
+- **Non-breaking `item` alias on the result wrapper.** The wrapper field has
+  historically been called `story`, which collides with item bodies that are
+  also sometimes called `story`. Both `.story` and `.item` now point at the
+  original input item on every result, so new code can use `.item`
+  unambiguously. `.story` stays for existing downstream callers.
+
 ### Improved — Scorer on topic-thin data + no-LLM mode (OOTB integration pass 3)
 
 - **`#interestMatch` no longer ties on items with empty `topics`.** When an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Improved — Scorer on topic-thin data + no-LLM mode (OOTB integration pass 3)
+
+- **`#interestMatch` no longer ties on items with empty `topics`.** When an
+  item has no tags (common for RSS without categories, text-only sources,
+  user-generated content), the scorer previously returned a flat 0.3 for every
+  such item — killing ranking differentiation. It now falls back to a pure
+  semantic match: embed the item's `title + summary`, compare to the user's
+  top interests, use the cosine similarity. Neutral 0.3 is only returned when
+  there is no text AND no embeddings AND no user interests to compare against.
+- **No-LLM mode now builds a real interest graph.** When `react()` is called
+  with an item that has no `topics` and no `TopicInsightEngine` is wired (i.e.
+  no LLM passed to the constructor), Marble now derives a small keyword set
+  from `item.title + summary` via a stopword-stripped top-N tokenizer and
+  uses them as fallback topics. Derived topics are marked `topics_derived:
+  true` on the history entry and receive a dampened interest boost (0.5×) to
+  reflect that they're heuristic, not user-curated.
+- **README now states that `learn()` is required for progressive improvement.**
+  `react()` / `feedbackBatch()` record signals, but clone evolution, the
+  inference engine, and the insight swarm only update inside `learn()`.
+  Typical integrations call it every N reactions or on a daily schedule.
+
 ### Added — Provider generalization (OOTB integration pass 2)
 
 - **New `openai-compatible` LLM provider.** Any OpenAI-compatible host

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ const stats = await marble.learn();
 // { insights: 7, candidates: 4, clones: 12 }
 ```
 
+> **`learn()` is required for the "Day 2 > Day 1" progressive improvement claim.**
+> `react()` and `feedbackBatch()` record signals into the KG, but the clone
+> population, inference engine, and insight swarm only update when you call
+> `learn()`. A typical integration calls `learn()` after every N reactions
+> (e.g. N=10) or on a daily schedule. Without it, ranking relies on interest
+> aggregation alone and will not show clone-driven improvements over time.
+
 **Run tests:**
 
 ```bash
@@ -152,8 +159,8 @@ cd marble && npm install && npm test
 
 ## Features
 
-- **Zero API keys** — Core scoring runs locally with ONNX embeddings
-- **Privacy-first** — All computation happens on your machine
+- **Pluggable providers** — Anthropic, OpenAI, DeepSeek, or any OpenAI-compatible host (Moonshot, Together, Fireworks, Groq, OpenRouter, Azure, vLLM) for LLM; OpenAI or DeepSeek for embeddings
+- **Privacy-first** — All user state stays on your machine; only per-item scoring/enrichment calls go out to the provider you configure
 - **Three modes** — Score (fast), Swarm (rich), WorldSim (B2B PMF)
 - **Implicit learning** — Learns from dwell time, scroll depth, forwards, silence
 - **Insight-driven KG** — Reasons about WHY, not just WHAT (see [docs/insight-kg.md](docs/insight-kg.md))

--- a/core/index.js
+++ b/core/index.js
@@ -93,13 +93,29 @@ export class Marble {
   }
 
   /**
-   * Score and rank items. Uses clone consensus when clones exist.
+   * Score and rank ALL items without slicing or arc reordering.
    *
-   * @param {Object[]} items - Candidate items (~100)
+   * Use this when you need the full ranking distribution — AUC / MRR
+   * evaluations, external rerankers, or surfacing more than `count` results.
+   * For top-N-with-optional-arc-ordering, use `select()` instead.
+   *
+   * The returned objects preserve the scorer's wrapper shape. Each has:
+   *   - `story`: the original input item (historical name, see `item` alias below)
+   *   - `item`: alias for `story` — use this in new code; `story` will be
+   *     deprecated in a future major
+   *   - `relevance_score`: number in [0, 1], the composite ranking signal
+   *   - `magic_score`: legacy alias of relevance_score kept for back-compat
+   *   - plus per-dimension components (`interest_match`, `temporal_relevance`,
+   *     `popularity_score`, `entity_affinity`, ...) when produced by the
+   *     scorer path; swarm/debate modes may populate a different subset
+   *
+   * Ordered descending by `relevance_score`; ties broken by `popularity_score`.
+   *
+   * @param {Object[]} items - Candidate items
    * @param {Object}   [context] - Ephemeral context (calendar, projects, mood)
-   * @returns {Object[]} Top items, arc-ordered
+   * @returns {Promise<Array<{ story: Object, item: Object, relevance_score: number, magic_score: number, [key: string]: any }>>}
    */
-  async select(items, context) {
+  async score(items, context) {
     if (!this.ready) await this.init();
 
     if (context) {
@@ -112,7 +128,7 @@ export class Marble {
       const swarm = new Swarm(this.kg, {
         mode: this.mode === 'debate' ? 'debate' : 'deep',
         llm: this.llm,
-        topN: this.count,
+        topN: items.length,
       });
       scored = await swarm.curate(items);
     } else {
@@ -140,6 +156,38 @@ export class Marble {
         (b.relevance_score ?? b.magic_score ?? 0) - (a.relevance_score ?? a.magic_score ?? 0)
       );
     }
+
+    // Non-breaking alias: wrapper.story → wrapper.item. Callers can start using
+    // `.item` immediately; `.story` is preserved for existing downstream code
+    // and will be deprecated in a future major version.
+    for (const entry of scored) {
+      if (entry && typeof entry === 'object' && entry.story && entry.item === undefined) {
+        entry.item = entry.story;
+      }
+    }
+
+    return scored;
+  }
+
+  /**
+   * Score and return the top `count` items, with optional arc reordering.
+   *
+   * Convenience wrapper around `score()` for the common "give me the top N"
+   * case. Identical scoring pipeline; differences:
+   *   - returns only the first `this.count` entries
+   *   - applies narrative arc reranking when `arcReorder: true` was passed
+   *     to the constructor (newsletter/content-curation use cases)
+   *
+   * For full-slate output (evaluations, external rerankers, large result
+   * sets), use `score()` instead.
+   *
+   * @param {Object[]} items - Candidate items (~100 typical)
+   * @param {Object}   [context] - Ephemeral context (calendar, projects, mood)
+   * @returns {Promise<Array<{ story: Object, item: Object, relevance_score: number, magic_score: number, [key: string]: any }>>}
+   *   Top `count` items, same wrapper shape as `score()`, optionally arc-ordered.
+   */
+  async select(items, context) {
+    const scored = await this.score(items, context);
 
     // Arc reranking is opt-in: only for newsletter/content-curation use cases
     // where narrative flow matters. For search, product recs, etc., keep pure ranking.

--- a/core/kg.js
+++ b/core/kg.js
@@ -33,6 +33,51 @@ function _extractJSON(text, shape = 'object') {
   try { return JSON.parse(m[0]); } catch { return null; }
 }
 
+// Minimal English stopword list for the no-LLM keyword fallback. Kept tiny to
+// avoid pulling in a dependency; the goal is "better than empty", not
+// production-grade NLP.
+const _STOPWORDS = new Set([
+  'a','an','the','and','or','but','if','then','than','so','of','to','for','in',
+  'on','at','by','with','from','about','into','over','under','between','through',
+  'is','are','was','were','be','been','being','have','has','had','do','does','did',
+  'will','would','could','should','may','might','must','can','cannot','this','that',
+  'these','those','i','you','he','she','it','we','they','them','their','our','your',
+  'my','me','us','as','not','no','yes','also','just','very','really','its','it\'s',
+  'up','down','out','off','too','any','some','all','more','most','much','many',
+  'one','two','three','like','get','got','go','going','gone','see','seen','saw',
+  'make','made','take','taken','took','find','found','come','came','come','gone',
+  'new','old','now','then','here','there','where','when','what','why','how','who',
+  'which','whose','been','being','being','not','don','doesn','isn','wasn','weren',
+]);
+
+/**
+ * Lightweight keyword extractor for the no-LLM mode. Splits on non-word chars,
+ * drops short tokens and stopwords, returns up to `limit` most-frequent tokens.
+ *
+ * This is a deliberately simple fallback — when no TopicInsightEngine is wired
+ * and the caller hands `react()` an item with no `topics`, we at least derive
+ * something the scorer can use rather than leaving the KG completely topic-thin.
+ *
+ * @param {string} text
+ * @param {number} [limit=5]
+ * @returns {string[]}
+ */
+function _extractKeywordsFromText(text, limit = 5) {
+  if (!text || typeof text !== 'string') return [];
+  const freq = new Map();
+  const tokens = text.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  for (const t of tokens) {
+    if (t.length < 3) continue;
+    if (_STOPWORDS.has(t)) continue;
+    if (/^\d+$/.test(t)) continue;
+    freq.set(t, (freq.get(t) || 0) + 1);
+  }
+  return [...freq.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([k]) => k);
+}
+
 export class KnowledgeGraph {
   constructor(dataPath) {
     this.dataPath = dataPath;
@@ -125,12 +170,34 @@ export class KnowledgeGraph {
    * @param {Object} [item=null] - Optional item metadata for secondary context extraction
    */
   recordReaction(itemId, reaction, topics, source, item = null) {
+    // No-LLM keyword fallback: when no TopicInsightEngine is wired and the
+    // caller provided no topics, derive a small keyword set from the item's
+    // title/summary so the interest graph gets a signal (otherwise every
+    // reaction in no-LLM mode contributes zero to the scorer's interest match).
+    // Marked derivedTopics on the history entry so downstream code can weight
+    // them lower if desired — they are a heuristic fallback, not user-curated.
+    let effectiveTopics = topics;
+    let derivedTopics = false;
+    if (
+      (!effectiveTopics || effectiveTopics.length === 0) &&
+      !this._topicInsightEngine &&
+      item
+    ) {
+      const text = `${item.title || ''} ${item.summary || item.description || ''}`.trim();
+      const kws = _extractKeywordsFromText(text);
+      if (kws.length) {
+        effectiveTopics = kws;
+        derivedTopics = true;
+      }
+    }
+
     const historyEntry = {
       item_id: itemId,
       reaction,
       date: new Date().toISOString(),
-      topics,
-      source
+      topics: effectiveTopics,
+      source,
+      ...(derivedTopics && { topics_derived: true }),
     };
 
     // Extract and store secondary context if item metadata provided
@@ -155,12 +222,15 @@ export class KnowledgeGraph {
 
     this.user.history.push(historyEntry);
 
-    // Update interest weights based on reaction
-    for (const topic of topics) {
+    // Update interest weights based on reaction. Derived-keyword topics get a
+    // dampened boost (half the normal rate) since they are heuristic, not
+    // user-declared.
+    const boostMultiplier = derivedTopics ? 0.5 : 1.0;
+    for (const topic of effectiveTopics || []) {
       if (reaction === 'up' || reaction === 'share') {
-        this.boostInterest(topic, reaction === 'share' ? 0.15 : 0.1);
+        this.boostInterest(topic, (reaction === 'share' ? 0.15 : 0.1) * boostMultiplier);
       } else if (reaction === 'down') {
-        this.decayInterest(topic, 0.05);
+        this.decayInterest(topic, 0.05 * boostMultiplier);
       }
     }
 

--- a/core/scorer.js
+++ b/core/scorer.js
@@ -708,13 +708,47 @@ export class Scorer {
 
   /**
    * How well does this story match the user's interest graph?
-   * Uses semantic embeddings for better matching (e.g., "EU digital markets act" matches "Shopify compliance")
+   * Uses semantic embeddings for better matching (e.g., "EU digital markets act" matches "Shopify compliance").
+   *
+   * When the item has no topics (common for RSS without tags, text-only sources,
+   * user-generated content), we still try to rank semantically against user
+   * interests using the item's title/summary text — previously this path
+   * returned a flat 0.3, which caused entire candidate sets to tie on this
+   * component and kill ranking differentiation.
+   *
    * @deprecated - kept for backward compatibility, use #computeTypedAlignments instead
    */
   async #interestMatch(story) {
-    if (!story.topics?.length) return 0.3; // neutral for untagged
+    const storyText = `${story.title || ''} ${story.summary || ''}`.trim();
 
-    const storyText = `${story.title} ${story.summary || ''}`.trim();
+    // Topic-less item: fall back to pure semantic match against user interests.
+    // Only degrade to the neutral 0.3 when we have neither text nor interests to
+    // compare against.
+    if (!story.topics?.length) {
+      if (!storyText) return 0.3;
+      try {
+        const userInterests = this.kg.getTopInterests?.() || [];
+        if (!userInterests.length) return 0.3;
+
+        const interestTexts = userInterests
+          .map(i => typeof i === 'string' ? i : i.name || i.topic)
+          .filter(Boolean);
+        if (!interestTexts.length) return 0.3;
+
+        const bestMatch = await this.embeddings.findMostSimilar(storyText, interestTexts, 0.2);
+        if (bestMatch && bestMatch.similarity > 0) {
+          return Math.min(1, bestMatch.similarity * 1.2);
+        }
+        // Semantic check ran but returned no match above threshold — signal is
+        // genuinely weak, but still non-zero so the outer score composition can
+        // use popularity/recency/etc. to differentiate.
+        return 0.15;
+      } catch (error) {
+        console.warn(`[scorer] topic-less interest match failed (${error.message}), using neutral score`);
+        return 0.3;
+      }
+    }
+
     if (!storyText) return 0.3;
 
     // Always compute Jaccard-based keyword overlap (free, no API).


### PR DESCRIPTION
## Summary

Stacks on #35. Three related improvements for downstream integrators running Marble on topic-thin datasets or without an LLM provider.

- **Scorer no longer ties on topic-less items.** `#interestMatch` previously returned a flat 0.3 for every item with empty `topics`, killing ranking differentiation across any dataset without tags (RSS without categories, user-generated content, text-only sources). Now falls back to a pure semantic match (embed `title + summary`, compare cosine similarity to user interests) when embeddings are available.
- **No-LLM mode now builds a real interest graph.** When `react()` is called with an item that has no `topics` and no `TopicInsightEngine` is wired, Marble derives a small keyword set from `title + summary` via a stopword-stripped tokenizer. Marked `topics_derived: true` on the history entry and receives a dampened (0.5×) interest boost to reflect that these are heuristic.
- **README documents the `learn()` requirement.** `react()`/`feedbackBatch()` record signals; clone evolution, inference engine, and insight swarm only update inside `learn()`. Also corrects a stale ONNX embeddings claim in the features list.

This is PR 3 of 4; depends on #35 (the base branch).

## Test plan

- [x] `npm test` — all 13 tests pass
- [x] No-LLM Marble reacts to a topic-less item → KG gains derived keyword interests (verified: "Rust memory safety ownership borrowing" → `rust`, `memory`, `safety`, `ownership`, `borrowing`)
- [x] `history[-1].topics_derived === true` when fallback fires
- [x] Derived interests get half the normal boost weight
- [x] Neutral 0.3 still returned when item has no text AND no user interests AND no embeddings (true degenerate case)

## Out of scope

Issue #5 from the integrator report (reaction replay doesn't drive improvement without `learn()`) is addressed here via documentation. The underlying aggregation question — whether `boostInterest` aggregation truly washes out signal as history grows — needs a reproducible harness before picking an implementation fix. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)