### PR TITLE
feat: public score() method + documented return shape (PR 4/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — API surface polish (OOTB integration pass 4)
+
+- **New `Marble#score(items, context)` public method.** Returns every scored
+  item (not sliced to `count`), sorted descending, without arc reordering.
+  Use this for AUC / MRR evaluations, external rerankers, or any case where
+  you need the full ranking distribution. `select()` is now a thin wrapper
+  around `score()` that applies the count slice and optional arc reorder.
+- **`select()` / `score()` return shape is now documented.** Previous JSDoc
+  said only "Top items, arc-ordered". The new `@returns` typedef spells out
+  the wrapper object: `story` (original item, legacy name), `item` (new
+  non-breaking alias), `relevance_score`, `magic_score`, and any
+  per-dimension components. Callers no longer have to dig into
+  `result[0].<??>` by trial and error.
+- **Non-breaking `item` alias on the result wrapper.** The wrapper field has
+  historically been called `story`, which collides with item bodies that are
+  also sometimes called `story`. Both `.story` and `.item` now point at the
+  original input item on every result, so new code can use `.item`
+  unambiguously. `.story` stays for existing downstream callers.
+
 ### Improved — Scorer on topic-thin data + no-LLM mode (OOTB integration pass 3)
 
 - **`#interestMatch` no longer ties on items with empty `topics`.** When an

--- a/core/index.js
+++ b/core/index.js
@@ -93,13 +93,29 @@ export class Marble {
   }
 
   /**
-   * Score and rank items. Uses clone consensus when clones exist.
+   * Score and rank ALL items without slicing or arc reordering.
    *
-   * @param {Object[]} items - Candidate items (~100)
+   * Use this when you need the full ranking distribution — AUC / MRR
+   * evaluations, external rerankers, or surfacing more than `count` results.
+   * For top-N-with-optional-arc-ordering, use `select()` instead.
+   *
+   * The returned objects preserve the scorer's wrapper shape. Each has:
+   *   - `story`: the original input item (historical name, see `item` alias below)
+   *   - `item`: alias for `story` — use this in new code; `story` will be
+   *     deprecated in a future major
+   *   - `relevance_score`: number in [0, 1], the composite ranking signal
+   *   - `magic_score`: legacy alias of relevance_score kept for back-compat
+   *   - plus per-dimension components (`interest_match`, `temporal_relevance`,
+   *     `popularity_score`, `entity_affinity`, ...) when produced by the
+   *     scorer path; swarm/debate modes may populate a different subset
+   *
+   * Ordered descending by `relevance_score`; ties broken by `popularity_score`.
+   *
+   * @param {Object[]} items - Candidate items
    * @param {Object}   [context] - Ephemeral context (calendar, projects, mood)
-   * @returns {Object[]} Top items, arc-ordered
+   * @returns {Promise<Array<{ story: Object, item: Object, relevance_score: number, magic_score: number, [key: string]: any }>>}
    */
-  async select(items, context) {
+  async score(items, context) {
     if (!this.ready) await this.init();
 
     if (context) {
@@ -112,7 +128,7 @@ export class Marble {
       const swarm = new Swarm(this.kg, {
         mode: this.mode === 'debate' ? 'debate' : 'deep',
         llm: this.llm,
-        topN: this.count,
+        topN: items.length,
       });
       scored = await swarm.curate(items);
     } else {
@@ -140,6 +156,38 @@ export class Marble {
         (b.relevance_score ?? b.magic_score ?? 0) - (a.relevance_score ?? a.magic_score ?? 0)
       );
     }
+
+    // Non-breaking alias: wrapper.story → wrapper.item. Callers can start using
+    // `.item` immediately; `.story` is preserved for existing downstream code
+    // and will be deprecated in a future major version.
+    for (const entry of scored) {
+      if (entry && typeof entry === 'object' && entry.story && entry.item === undefined) {
+        entry.item = entry.story;
+      }
+    }
+
+    return scored;
+  }
+
+  /**
+   * Score and return the top `count` items, with optional arc reordering.
+   *
+   * Convenience wrapper around `score()` for the common "give me the top N"
+   * case. Identical scoring pipeline; differences:
+   *   - returns only the first `this.count` entries
+   *   - applies narrative arc reranking when `arcReorder: true` was passed
+   *     to the constructor (newsletter/content-curation use cases)
+   *
+   * For full-slate output (evaluations, external rerankers, large result
+   * sets), use `score()` instead.
+   *
+   * @param {Object[]} items - Candidate items (~100 typical)
+   * @param {Object}   [context] - Ephemeral context (calendar, projects, mood)
+   * @returns {Promise<Array<{ story: Object, item: Object, relevance_score: number, magic_score: number, [key: string]: any }>>}
+   *   Top `count` items, same wrapper shape as `score()`, optionally arc-ordered.
+   */
+  async select(items, context) {
+    const scored = await this.score(items, context);
 
     // Arc reranking is opt-in: only for newsletter/content-curation use cases
     // where narrative flow matters. For search, product recs, etc., keep pure ranking.


### PR DESCRIPTION
## Summary

Stacks on #36. Final pass — three small API-surface cleanups for integrators.

- **New `Marble#score(items, context)` public method.** Returns every scored item, sorted descending, without slicing or arc reorder. For AUC/MRR evaluations, external rerankers, or any case where you need the full ranking distribution. `select()` now wraps it.
- **`select()` / `score()` return shape is documented.** Previous JSDoc said only "Top items, arc-ordered" — callers had to discover fields by trial and error. New `@returns` typedef spells out every wrapper field.
- **Non-breaking `item` alias on the result wrapper.** `.story` and `.item` both point at the original input item, so new code can use `.item` unambiguously while existing code keeps working. The legacy `.story` name collides with item bodies that are also called `story` in some domains.

This is PR 4 of 4; depends on #36 (the base branch).

## Test plan

- [x] `npm test` — all 13 tests pass
- [x] `marble.score(items)` with 10 items returns 10 scored entries, sorted descending
- [x] `marble.select(items)` with 10 items + `count: 3` returns the top 3
- [x] `result[0].item === result[0].story` (alias correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)