### PR TITLE
feat: temporal truth v1 — episodes, source timestamps, reconciliation, decay

### DIFF
--- a/core/conversation-miner.js
+++ b/core/conversation-miner.js
@@ -104,11 +104,55 @@ Rules:
 
 // ─── FORMAT PARSERS ───────────────────────────────────────────────────────────
 
+/**
+ * Best-effort extraction of a conversation's real-world creation time.
+ * ChatGPT exports carry `create_time` as unix seconds; Claude exports carry
+ * `created_at` as ISO. Fall back to the latest per-message timestamp, then to
+ * null — callers must treat null as "unknown" rather than silently stamping
+ * the current wall-clock time.
+ *
+ * @param {Object} conv - Raw conversation object from the export
+ * @returns {string|null} ISO-8601 timestamp or null
+ */
+function extractConversationDate(conv) {
+  if (!conv || typeof conv !== 'object') return null;
+  if (typeof conv.create_time === 'number' && Number.isFinite(conv.create_time)) {
+    return new Date(conv.create_time * 1000).toISOString();
+  }
+  if (typeof conv.created_at === 'string' && conv.created_at) {
+    const d = new Date(conv.created_at);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+  }
+  if (typeof conv.update_time === 'number' && Number.isFinite(conv.update_time)) {
+    return new Date(conv.update_time * 1000).toISOString();
+  }
+  // Walk messages looking for a per-message timestamp (ChatGPT mapping nodes
+  // often carry `create_time`). This catches exports where the conversation
+  // header is missing a top-level time.
+  if (conv.mapping) {
+    for (const node of Object.values(conv.mapping)) {
+      const t = node?.message?.create_time;
+      if (typeof t === 'number' && Number.isFinite(t)) {
+        return new Date(t * 1000).toISOString();
+      }
+    }
+  }
+  if (Array.isArray(conv.chat_messages)) {
+    for (const m of conv.chat_messages) {
+      if (m?.created_at) {
+        const d = new Date(m.created_at);
+        if (!Number.isNaN(d.getTime())) return d.toISOString();
+      }
+    }
+  }
+  return null;
+}
+
 function parseChatGPTFormat(data) {
   const conversations = data.conversations || (Array.isArray(data) ? data : [data]);
-  const chunks = [];
+  const result = [];
 
-  for (const conv of conversations) {
+  for (const [idx, conv] of conversations.entries()) {
     const messages = [];
 
     if (conv.mapping) {
@@ -146,19 +190,37 @@ function parseChatGPTFormat(data) {
     }
 
     if (messages.length > 0) {
-      chunks.push(messages);
+      result.push({
+        messages,
+        source_date: extractConversationDate(conv),
+        title: conv.title || conv.name || `conversation_${idx}`,
+        id: conv.id || conv.uuid || null,
+      });
     }
   }
 
-  return chunks;
+  return result;
 }
 
+/**
+ * Returns an array of `{ messages, source_date, title, id }` objects. Every
+ * supported export format is normalised to this shape so downstream code can
+ * carry source timestamps without branching per-format. `source_date` may be
+ * null — the caller must handle that rather than silently substituting now.
+ *
+ * @param {any} data - Raw parsed JSON from an export file
+ * @returns {Array<{ messages: Array, source_date: string|null, title: string, id: string|null }>}
+ */
 function parseExport(data) {
-  if (Array.isArray(data) && data[0]?.role) return [data];
+  if (Array.isArray(data) && data[0]?.role) {
+    return [{ messages: data, source_date: null, title: 'conversation_0', id: null }];
+  }
   if (data.conversations || (Array.isArray(data) && data[0]?.mapping)) return parseChatGPTFormat(data);
   if (data.chat_messages) return parseChatGPTFormat({ conversations: [data] });
   if (data.mapping) return parseChatGPTFormat({ conversations: [data] });
-  if (Array.isArray(data.messages)) return [data.messages];
+  if (Array.isArray(data.messages)) {
+    return [{ messages: data.messages, source_date: null, title: 'conversation_0', id: null }];
+  }
   return [];
 }
 
@@ -290,29 +352,40 @@ export class ConversationMiner {
   }
 
   /**
-   * Ingest a chat export file and return KG nodes extracted from it.
-   * No cap by default — processes ALL conversations.
-   * Deduplicates across chunks automatically.
+   * Parse an export file into the normalised conversation list used
+   * internally. Callers that want to build episodes before extraction (like
+   * `ingestIntoKG`) use this directly so they don't re-read the file.
+   *
+   * @param {string} chatExportPath
+   * @returns {Promise<Array<{ messages, source_date, title, id }>>}
    */
-  async ingest(chatExportPath) {
+  async parseFile(chatExportPath) {
     const raw = await readFile(chatExportPath, 'utf-8');
     const data = JSON.parse(raw);
     const conversations = parseExport(data);
-
     if (conversations.length === 0) {
       throw new Error(`[ConversationMiner] No parseable conversations found in ${chatExportPath}`);
     }
+    return conversations;
+  }
 
+  /**
+   * Chunk-mode extraction over already-parsed conversations.
+   * Nodes carry `source_date` and `source_conversation_index` back-pointers.
+   * @private
+   */
+  async _extractFromConversations(conversations) {
     const allNodes = [];
     let chunksProcessed = 0;
+    let capHit = false;
 
-    for (const messages of conversations) {
-      if (chunksProcessed >= this.maxChunks) break;
+    for (const [convIdx, conv] of conversations.entries()) {
+      if (chunksProcessed >= this.maxChunks) { capHit = true; break; }
 
-      const chunks = buildChunks(messages, this.chunkSize);
+      const chunks = buildChunks(conv.messages, this.chunkSize);
 
       for (const chunk of chunks) {
-        if (chunksProcessed >= this.maxChunks) break;
+        if (chunksProcessed >= this.maxChunks) { capHit = true; break; }
         if (chunk.length === 0) continue;
 
         const prompt = EXTRACTION_PROMPT + formatChunk(chunk);
@@ -328,7 +401,11 @@ export class ConversationMiner {
         const rawNodes = parseNodes(responseText);
         for (const raw of rawNodes) {
           const node = normalizeNode(raw);
-          if (node) allNodes.push(node);
+          if (node) {
+            node.source_date = conv.source_date;
+            node.source_conversation_index = convIdx;
+            allNodes.push(node);
+          }
         }
 
         chunksProcessed++;
@@ -338,32 +415,36 @@ export class ConversationMiner {
       }
     }
 
-    // Dedup across all chunks
+    if (capHit) {
+      console.warn(
+        `[ConversationMiner] maxChunks cap of ${this.maxChunks} reached — ` +
+        'remaining conversations were NOT processed. ' +
+        'Raise or remove `maxChunks` to process the entire file.'
+      );
+    }
+
+    // Dedup across all chunks. Dedup preserves the first-seen `source_date`
+    // and `source_conversation_index` — keeping them lets the downstream
+    // episode wiring work on the merged fact.
     return dedup(allNodes);
   }
 
   /**
-   * Ingest using exchange-mode (user+assistant pairs).
-   * No cap by default. Deduplicates automatically.
+   * Exchange-mode extraction over already-parsed conversations.
+   * @private
    */
-  async ingestExchanges(chatExportPath) {
-    const raw = await readFile(chatExportPath, 'utf-8');
-    const data = JSON.parse(raw);
-    const conversations = parseExport(data);
-
-    if (conversations.length === 0) {
-      throw new Error(`[ConversationMiner] No parseable conversations found in ${chatExportPath}`);
-    }
-
+  async _extractExchangesFromConversations(conversations) {
     const allNodes = [];
     let exchangesProcessed = 0;
     const maxExchanges = this.maxChunks === Infinity ? Infinity : this.maxChunks * this.chunkSize;
+    let capHit = false;
 
-    for (const messages of conversations) {
-      const exchanges = buildExchangePairs(messages);
+    for (const [convIdx, conv] of conversations.entries()) {
+      if (exchangesProcessed >= maxExchanges) { capHit = true; break; }
+      const exchanges = buildExchangePairs(conv.messages);
 
       for (const exchange of exchanges) {
-        if (exchangesProcessed >= maxExchanges) break;
+        if (exchangesProcessed >= maxExchanges) { capHit = true; break; }
 
         const text = `[USER]: ${exchange.user}\n\n[ASSISTANT]: ${exchange.assistant}`;
         const prompt = EXCHANGE_EXTRACTION_PROMPT + text;
@@ -379,7 +460,11 @@ export class ConversationMiner {
         const rawNodes = parseNodes(responseText);
         for (const raw of rawNodes) {
           const node = normalizeNode(raw);
-          if (node) allNodes.push(node);
+          if (node) {
+            node.source_date = conv.source_date;
+            node.source_conversation_index = convIdx;
+            allNodes.push(node);
+          }
         }
 
         exchangesProcessed++;
@@ -389,7 +474,37 @@ export class ConversationMiner {
       }
     }
 
+    if (capHit) {
+      console.warn(
+        `[ConversationMiner] maxExchanges cap reached — remaining exchanges were NOT processed. ` +
+        'Raise or remove `maxChunks` to process the entire file.'
+      );
+    }
+
     return dedup(allNodes);
+  }
+
+  /**
+   * Ingest a chat export file and return KG nodes extracted from it.
+   *
+   * Nodes carry the source conversation's real-world timestamp (`source_date`)
+   * and a back-pointer (`source_conversation_index`) that `ingestIntoKG()`
+   * uses to pair each node with an episode record. No wall-clock substitution
+   * happens here — when a conversation has no extractable date, nodes get a
+   * null `source_date` and the caller decides how to handle that.
+   */
+  async ingest(chatExportPath) {
+    const conversations = await this.parseFile(chatExportPath);
+    return this._extractFromConversations(conversations);
+  }
+
+  /**
+   * Ingest using exchange-mode (user+assistant pairs).
+   * Same source-timestamp handling as `ingest()`.
+   */
+  async ingestExchanges(chatExportPath) {
+    const conversations = await this.parseFile(chatExportPath);
+    return this._extractExchangesFromConversations(conversations);
   }
 
   /**
@@ -440,45 +555,187 @@ export class ConversationMiner {
   }
 
   /**
-   * Full pipeline: extract → dedup → infer → merge → write to KG.
+   * Full pipeline: extract → dedup → infer → episodes → write to KG.
+   *
+   * Before extraction runs, one episode is created per source conversation
+   * (via `kg.addEpisode()`). Every extracted fact is written to the KG with
+   * `validFrom = source_date` and `episodeId` pointing to the conversation it
+   * came from — so provenance survives through dedup and facts age from the
+   * date the user actually said the thing, not the date the miner ran.
+   *
+   * Inference facts inherit provenance from their source facts (all referenced
+   * source_conversation_indexes merge into the inference's evidence array).
    *
    * @param {string} chatExportPath
    * @param {Object} kg - KnowledgeGraph instance
    * @param {Object} [opts]
    * @param {boolean} [opts.exchangeMode=true]
    * @param {boolean} [opts.runInference=true]
+   * @param {string} [opts.sourceLabel] - Episode `source` field. Defaults to
+   *   'chat-export' — override when ingesting a specific provider so
+   *   downstream provenance queries can filter by source.
    * @returns {Promise<Object>} stats
    */
   async ingestIntoKG(chatExportPath, kg, opts = {}) {
-    const useExchanges = opts.exchangeMode !== false;
-    const runInference = opts.runInference !== false;
+    const sourceLabel = opts.sourceLabel || 'chat-export';
+    const conversations = await this.parseFile(chatExportPath);
+    return this._runPipeline(conversations, kg, {
+      exchangeMode: opts.exchangeMode !== false,
+      runInference: opts.runInference !== false,
+      episodeMeta: (idx, conv) => ({
+        source: sourceLabel,
+        source_date: conv.source_date,
+        content_summary: conv.title,
+        metadata: {
+          file: chatExportPath,
+          conversation_index: idx,
+          message_count: (conv.messages || []).length,
+          ...(conv.id ? { conversation_id: conv.id } : {}),
+        },
+      }),
+    });
+  }
 
-    // Phase 1: Extract
-    const nodes = useExchanges
-      ? await this.ingestExchanges(chatExportPath)
-      : await this.ingest(chatExportPath);
+  /**
+   * Ingest generic `Episode` objects — the format-agnostic entry point.
+   *
+   * An episode is `{ id?, source, source_date, content, metadata? }`. This is
+   * the contract consumers reach for when their source isn't a ChatGPT/Claude
+   * export: journals, emails, meeting notes, Slack, anything textual.
+   * Extraction, dedup, inference, and provenance wiring are identical to
+   * `ingestIntoKG()` — the only difference is that the "conversation" is a
+   * single user-role message with the episode's raw text.
+   *
+   * @param {Array<{id?: string, source?: string, source_date?: string, content: string, metadata?: object}>} episodes
+   * @param {Object} kg - KnowledgeGraph instance
+   * @param {Object} [opts]
+   * @param {boolean} [opts.runInference=true]
+   * @returns {Promise<Object>} Same stats shape as `ingestIntoKG()`
+   */
+  async ingestEpisodesIntoKG(episodes, kg, opts = {}) {
+    if (!Array.isArray(episodes) || episodes.length === 0) {
+      throw new Error('[ConversationMiner] ingestEpisodesIntoKG requires a non-empty episodes array');
+    }
 
-    // Phase 2: Inference pass
+    const conversations = episodes.map((ep, idx) => ({
+      // Each episode becomes a single-message conversation so the extraction
+      // prompt sees user text to mine. The assistant side is empty — exchange
+      // mode degrades to chunk mode automatically.
+      messages: [{ role: 'user', content: String(ep.content || '') }],
+      source_date: ep.source_date || null,
+      title: ep.id || `episode_${idx}`,
+      id: ep.id || null,
+      _original: ep,
+    }));
+
+    return this._runPipeline(conversations, kg, {
+      // Exchange mode requires an assistant turn; force chunk mode for
+      // episodes so the extraction prompt receives the single user message.
+      exchangeMode: false,
+      runInference: opts.runInference !== false,
+      episodeMeta: (idx, conv) => ({
+        id: conv._original.id,
+        source: conv._original.source || 'generic',
+        source_date: conv._original.source_date || null,
+        content: conv._original.content || '',
+        content_summary: conv._original.content_summary,
+        metadata: conv._original.metadata,
+      }),
+    });
+  }
+
+  /**
+   * Shared pipeline used by `ingestIntoKG` and `ingestEpisodesIntoKG`:
+   * create episodes, extract, infer, write back with provenance.
+   * @private
+   */
+  async _runPipeline(conversations, kg, opts) {
+    const { exchangeMode, runInference, episodeMeta } = opts;
+
+    // Phase 0: one episode per conversation. Skip if the KG predates the
+    // episode schema — keeps legacy in-memory KG mocks working.
+    const supportsEpisodes = typeof kg.addEpisode === 'function';
+    const convEpisodeIds = new Array(conversations.length).fill(null);
+    if (supportsEpisodes) {
+      for (const [idx, conv] of conversations.entries()) {
+        const meta = episodeMeta(idx, conv);
+        const messages = conv.messages || [];
+        const previewFallback = messages.slice(0, 3)
+          .map(m => `[${m.role}] ${String(m.content || '').slice(0, 200)}`)
+          .join('\n') + (messages.length > 3 ? `\n… +${messages.length - 3} more messages` : '');
+        const ep = kg.addEpisode({
+          id: meta.id,
+          source: meta.source,
+          source_date: meta.source_date,
+          content: meta.content ?? previewFallback,
+          content_summary: meta.content_summary,
+          metadata: meta.metadata,
+        });
+        convEpisodeIds[idx] = ep.id;
+      }
+    }
+
+    // Phase 1: extract
+    const nodes = exchangeMode
+      ? await this._extractExchangesFromConversations(conversations)
+      : await this._extractFromConversations(conversations);
+
+    // Phase 2: inference
     let inferenceNodes = [];
     if (runInference && nodes.length >= 3) {
       inferenceNodes = await this.inferFromNodes(nodes);
+      const allEpisodeIds = [...new Set(
+        nodes.map(n => convEpisodeIds[n.source_conversation_index]).filter(Boolean)
+      )];
+      const latest = nodes.map(n => n.source_date).filter(Boolean).sort().pop();
+      for (const inf of inferenceNodes) {
+        inf._episode_ids = allEpisodeIds;
+        inf.source_date = latest || null;
+      }
     }
 
-    const allNodes = [...nodes, ...inferenceNodes];
+    // Phase 3: write back with provenance
+    const stats = {
+      ingested: 0,
+      beliefs: 0,
+      preferences: 0,
+      identities: 0,
+      emotions: 0,
+      inferences: inferenceNodes.length,
+      duplicates_merged: nodes.reduce((s, n) => s + ((n.evidence_count || 1) - 1), 0),
+      episodes: supportsEpisodes ? convEpisodeIds.filter(Boolean).length : 0,
+    };
 
-    // Phase 3: Write to KG
-    const stats = { ingested: 0, beliefs: 0, preferences: 0, identities: 0, emotions: 0, inferences: inferenceNodes.length, duplicates_merged: nodes.reduce((s, n) => s + ((n.evidence_count || 1) - 1), 0) };
+    const resolveEpisodeId = (node) => {
+      if (node._episode_ids?.length) return node._episode_ids[0];
+      const idx = node.source_conversation_index;
+      return (idx != null && convEpisodeIds[idx]) || null;
+    };
 
-    for (const node of allNodes) {
+    for (const node of [...nodes, ...inferenceNodes]) {
       try {
+        const addOpts = {
+          validFrom: node.source_date || undefined,
+          episodeId: resolveEpisodeId(node),
+        };
+
         if (node.type === 'belief' || node.type === 'decision') {
-          kg.addBelief(node.topic, node.value, node.confidence);
+          kg.addBelief(node.topic, node.value, node.confidence, addOpts);
+          if (node._episode_ids?.length > 1) {
+            this.#linkAdditionalEpisodes(kg, 'belief', node.topic, node._episode_ids);
+          }
           stats.beliefs++;
         } else if (node.type === 'preference') {
-          kg.addPreference(node.topic, node.value, node.confidence);
+          kg.addPreference(node.topic, node.value, node.confidence, addOpts);
+          if (node._episode_ids?.length > 1) {
+            this.#linkAdditionalEpisodes(kg, 'preference', node.topic, node._episode_ids);
+          }
           stats.preferences++;
         } else if (node.type === 'identity') {
-          kg.addIdentity(node.topic, node.value, node.confidence);
+          kg.addIdentity(node.topic, node.value, node.confidence, addOpts);
+          if (node._episode_ids?.length > 1) {
+            this.#linkAdditionalEpisodes(kg, 'identity', node.topic, node._episode_ids);
+          }
           stats.identities++;
         }
 
@@ -497,6 +754,31 @@ export class ConversationMiner {
     }
 
     return stats;
+  }
+
+  /**
+   * Append extra episode ids to the most recent active fact of (type, topic).
+   * Used for inference nodes that trace to multiple source episodes — the
+   * first id is linked via `addBelief/Preference/Identity({ episodeId })`,
+   * the rest are appended here.
+   * @private
+   */
+  #linkAdditionalEpisodes(kg, type, topic, episodeIds) {
+    const collection = type === 'belief' ? kg.user?.beliefs
+      : type === 'preference' ? kg.user?.preferences
+      : type === 'identity' ? kg.user?.identities
+      : null;
+    if (!collection) return;
+    const key = (topic || '').toLowerCase();
+    const fact = collection
+      .filter(f => !f.valid_to)
+      .reverse()
+      .find(f => (f.topic || f.type || f.role || '').toLowerCase() === key);
+    if (!fact) return;
+    if (!Array.isArray(fact.evidence)) fact.evidence = [];
+    for (const id of episodeIds) {
+      if (!fact.evidence.includes(id)) fact.evidence.push(id);
+    }
   }
 
   /**

--- a/core/index.js
+++ b/core/index.js
@@ -11,7 +11,7 @@
  *   7. investigate(opts)         → adaptive committee fills gaps
  */
 
-import { KnowledgeGraph } from './kg.js';
+import { KnowledgeGraph, DEFAULT_RECONCILIATION_RULES, DEFAULT_DECAY_CONFIG } from './kg.js';
 import { Scorer } from './scorer.js';
 import { ArcReranker } from './arc.js';
 import { Swarm } from './swarm.js';
@@ -58,6 +58,19 @@ export class Marble {
    * @param {number}   [opts.coldStartThreshold=10] - Signals needed before full personalization
    * @param {number}   [opts.cloneBoostWeight=0.3] - How much clone consensus influences scoring
    * @param {boolean}  [opts.silent=false] - Suppress construction-time warnings about missing providers
+   * @param {Object}   [opts.reconciliationRules] - Per-slot cardinality rules
+   *   for post-ingest reconciliation. Shape:
+   *   `{ beliefs: { topic: 'one'|'many' }, preferences: { type: 'one'|'many' }, identities: { role: 'one'|'many' } }`
+   *   Slots marked 'one' are collapsed to a single active fact after every
+   *   `ingestEpisodes()` / `ingestConversations()` call — older versions are
+   *   closed via `valid_to`. Unlisted slots retain 'many' (no forced
+   *   uniqueness). Pass `null` to fully disable reconciliation. Defaults to
+   *   `DEFAULT_RECONCILIATION_RULES` (a conservative starter set).
+   * @param {Object}   [opts.decayConfig] - Temporal-decay parameters for
+   *   `getActiveBeliefs/Preferences/Identities`. Shape:
+   *   `{ halfLifeDays, minEffectiveStrength }`. Defaults to half-life 365
+   *   days, threshold 0 (no filtering — back-compat preserved). Raise the
+   *   threshold to drop stale facts from the active view.
    */
   constructor({
     storage = './marble-kg.json',
@@ -69,8 +82,10 @@ export class Marble {
     coldStartThreshold = 10,
     cloneBoostWeight = 0.3,
     silent = false,
+    reconciliationRules = DEFAULT_RECONCILIATION_RULES,
+    decayConfig = DEFAULT_DECAY_CONFIG,
   } = {}) {
-    this.kg = new KnowledgeGraph(storage);
+    this.kg = new KnowledgeGraph(storage, { decayConfig });
     this.scorer = new Scorer(this.kg, { coldStartThreshold, embeddings });
     this.arc = new ArcReranker();
     this.count = count;
@@ -79,6 +94,7 @@ export class Marble {
     this.embeddings = embeddings;
     this.arcReorder = arcReorder;
     this.cloneBoostWeight = Math.max(0, Math.min(1, cloneBoostWeight));
+    this.reconciliationRules = reconciliationRules;
     this.ready = false;
 
     // Lazy-init containers
@@ -463,9 +479,15 @@ export class Marble {
    * Ingest a chat export (ChatGPT, Claude, generic) into the KG.
    * Extracts beliefs, preferences, identities, then runs inference pass.
    *
+   * This is a format-specific convenience wrapper. For arbitrary sources
+   * (journals, email, notes, anything textual), use `ingestEpisodes()` — it
+   * accepts a generic `Episode` shape you can produce from any adapter.
+   *
    * @param {string} filePath - Path to export JSON
    * @param {Object} [opts]
    * @param {boolean} [opts.runInference=true] - Run psychological inference pass
+   * @param {string}  [opts.sourceLabel] - Override the episode `source` label
+   *   (default: 'chat-export').
    * @returns {Promise<Object>} Ingestion stats
    */
   async ingestConversations(filePath, opts = {}) {
@@ -482,10 +504,65 @@ export class Marble {
     const result = await miner.ingestIntoKG(filePath, this.kg, {
       exchangeMode: opts.exchangeMode !== false,
       runInference: opts.runInference !== false,
+      sourceLabel: opts.sourceLabel,
     });
+
+    const reconciled = this._reconcile();
+    if (reconciled) result.reconciled = reconciled;
 
     await this.kg.save();
     return result;
+  }
+
+  /**
+   * Ingest generic episodes into the KG — the format-agnostic entry point.
+   *
+   * An `Episode` is the minimal shape Marble needs to build provenance:
+   *   { id?, source, source_date, content, metadata? }
+   *
+   * Pass whatever you can produce from your own sources. Marble will:
+   *   1. Record each episode in `kg.user.episodes[]` (dedup by id+content_hash)
+   *   2. Extract beliefs/preferences/identities from `content` via the LLM
+   *   3. Stamp every extracted fact with `valid_from = source_date`
+   *   4. Link each fact to its origin episode(s) via `evidence: [episode_id]`
+   *
+   * @param {Array<{id?: string, source?: string, source_date?: string, content: string, metadata?: object}>} episodes
+   * @param {Object} [opts]
+   * @param {boolean} [opts.runInference=true]
+   * @returns {Promise<Object>} Same stats shape as `ingestConversations()`
+   */
+  async ingestEpisodes(episodes, opts = {}) {
+    if (!this.llm) {
+      throw new Error('ingestEpisodes() requires an LLM provider.');
+    }
+    if (!this.ready) await this.init();
+
+    const { ConversationMiner } = await import('./conversation-miner.js');
+    const miner = new ConversationMiner(this.llm, {
+      onProgress: opts.onProgress || null,
+    });
+
+    const result = await miner.ingestEpisodesIntoKG(episodes, this.kg, {
+      runInference: opts.runInference !== false,
+    });
+
+    const reconciled = this._reconcile();
+    if (reconciled) result.reconciled = reconciled;
+
+    await this.kg.save();
+    return result;
+  }
+
+  /**
+   * Run the configured reconciliation rules against the KG.
+   * Returns the counts or null if reconciliation is disabled (rules === null).
+   * Callers that ingest via the miner directly can opt into reconciliation by
+   * calling `kg.reconcile()` themselves.
+   * @private
+   */
+  _reconcile() {
+    if (this.reconciliationRules === null) return null;
+    return this.kg.reconcile(this.reconciliationRules);
   }
 
   /**
@@ -511,7 +588,7 @@ export class Marble {
 // ═══════════════════════════════════════════════════════════
 // TIER 2: Core components (direct access for advanced use)
 // ═══════════════════════════════════════════════════════════
-export { KnowledgeGraph } from './kg.js';
+export { KnowledgeGraph, KG_VERSION, DEFAULT_RECONCILIATION_RULES, DEFAULT_DECAY_CONFIG } from './kg.js';
 export { Scorer } from './scorer.js';
 export { ArcReranker } from './arc.js';
 

--- a/core/kg.js
+++ b/core/kg.js
@@ -9,11 +9,60 @@
  * - preference: Explicit preferences and patterns
  * - identity: Role/identity attributes about the user
  * - confidence: Confidence levels in knowledge areas
+ * - episode: Source record every fact can point back to
  */
 
 import { readFile, writeFile } from 'fs/promises';
+import { createHash } from 'crypto';
 import { extractEntityAttributes } from './entity-extractor.js';
 import { embeddings as defaultEmbeddings } from './embeddings.js';
+
+/**
+ * On-disk schema version. Bump when the saved JSON shape changes in a way that
+ * requires migration, and add a case to `#migrate()` below.
+ */
+export const KG_VERSION = 1;
+
+/**
+ * Default reconciliation rules — a conservative starter set that marks the
+ * most common single-value slots as cardinality "one" so that ingesting
+ * contradictory facts about them closes the older version automatically.
+ *
+ * Consumers can extend or fully replace this map via the `Marble` constructor
+ * option `reconciliationRules`. Unlisted slots retain "many" (no forced
+ * uniqueness) — a safe default that won't collapse distinct preferences.
+ */
+export const DEFAULT_RECONCILIATION_RULES = {
+  beliefs: {
+    current_city: 'one',
+    current_employer: 'one',
+    current_role: 'one',
+  },
+  preferences: {
+    primary_diet: 'one',
+    primary_language: 'one',
+    time_zone: 'one',
+  },
+  identities: {
+    current_city: 'one',
+    current_employer: 'one',
+    current_role: 'one',
+    current_school: 'one',
+  },
+};
+
+/**
+ * Default decay configuration for `getActive*` views. Half-life controls how
+ * fast `effective_strength = strength * 2^(-age_days / halfLifeDays)` shrinks
+ * as facts age. Threshold 0 preserves the pre-decay behaviour — nothing is
+ * filtered out unless consumers explicitly raise it. Historical queries
+ * (`asOf` in the past) compute age relative to that point, not today, so
+ * `getStateAt()` is unaffected.
+ */
+export const DEFAULT_DECAY_CONFIG = {
+  halfLifeDays: 365,
+  minEffectiveStrength: 0,
+};
 
 /**
  * Walk `src` and return a version with any unclosed `{`, `[`, or `"` closed
@@ -216,7 +265,7 @@ function _extractKeywordsFromText(text, limit = 5) {
 }
 
 export class KnowledgeGraph {
-  constructor(dataPath) {
+  constructor(dataPath, opts = {}) {
     this.dataPath = dataPath;
     this.user = null;
     this.items = new Map();
@@ -226,6 +275,9 @@ export class KnowledgeGraph {
     // Native vector index: node_id → Float32Array embedding
     this._vectorIndex = new Map();
     this._vectorIndexMeta = new Map();   // node_id → { type, node, text }
+    // Decay config — overridable per-instance so consumers with long-lived
+    // facts (preferences that rarely change) can use a longer half-life.
+    this.decayConfig = { ...DEFAULT_DECAY_CONFIG, ...(opts.decayConfig || {}) };
   }
 
   /**
@@ -242,16 +294,35 @@ export class KnowledgeGraph {
       const data = JSON.parse(raw);
       this.user = data.user || this.#defaultUser();
       this._dimensionalPreferences = data._dimensionalPreferences || [];
+      this.version = data.version ?? 0;
+      if (this.version < KG_VERSION) this.#migrate();
       return this;
     } catch {
       this.user = this.#defaultUser();
       this._dimensionalPreferences = [];
+      this.version = KG_VERSION;
       return this;
     }
   }
 
+  /**
+   * Forward-migrate the in-memory KG from whatever `this.version` was loaded
+   * to `KG_VERSION`. Runs on every load when the on-disk file predates the
+   * current schema — migrations must be idempotent and safe to run repeatedly.
+   *
+   * Migration map:
+   *   0 → 1: add `episodes: []` to user
+   */
+  #migrate() {
+    if (this.version < 1) {
+      if (!Array.isArray(this.user.episodes)) this.user.episodes = [];
+    }
+    this.version = KG_VERSION;
+  }
+
   async save() {
     const data = {
+      version: KG_VERSION,
       user: this.user,
       _dimensionalPreferences: this._dimensionalPreferences,
       updated_at: new Date().toISOString()
@@ -452,9 +523,18 @@ export class KnowledgeGraph {
    * @param {string} topic - Topic or domain
    * @param {string} claim - The belief statement
    * @param {number} strength - Belief strength (0-1)
+   * @param {Object} [opts]
+   * @param {string} [opts.validFrom] - ISO date when this belief became true in
+   *   the real world (source date). Defaults to now. Pass the source timestamp
+   *   here so temporal queries work against the source timeline, not the
+   *   ingest timeline.
+   * @param {string} [opts.episodeId] - Provenance pointer. Appended to the
+   *   fact's `evidence: [episode_id]` array so `getFactProvenance()` can trace
+   *   back to the source.
    */
-  addBelief(topic, claim, strength = 0.7) {
+  addBelief(topic, claim, strength = 0.7, opts = {}) {
     const now = new Date().toISOString();
+    const validFrom = opts.validFrom || now;
     const active = this.user.beliefs.find(b =>
       b.topic.toLowerCase() === topic.toLowerCase() && !b.valid_to
     );
@@ -465,20 +545,25 @@ export class KnowledgeGraph {
         active.strength = Math.min(1, strength);
         active.evidence_count = (active.evidence_count || 0) + 1;
         active.recorded_at = now;
+        if (opts.episodeId) this.#linkEvidence(active, opts.episodeId);
         return;
       }
-      // Contradiction: close old fact
-      active.valid_to = now;
+      // Contradiction: close old fact. Use the incoming validFrom (source
+      // date) so the closure lines up on the source timeline, not wall-clock.
+      active.valid_to = validFrom;
     }
 
-    this.user.beliefs.push({
+    const fact = {
       topic, claim,
       strength: Math.min(1, strength),
       evidence_count: 1,
-      valid_from: now,
+      valid_from: validFrom,
       valid_to: null,
-      recorded_at: now
-    });
+      recorded_at: now,
+      evidence: [],
+    };
+    if (opts.episodeId) this.#linkEvidence(fact, opts.episodeId);
+    this.user.beliefs.push(fact);
   }
 
   /**
@@ -495,16 +580,25 @@ export class KnowledgeGraph {
 
   /**
    * Return all beliefs that are active (valid_to is null or > asOf).
+   *
+   * Each returned belief is a shallow copy with two extra fields computed at
+   * read time:
+   *   - `effective_strength = strength * 2^(-age_days / halfLifeDays)`
+   *   - `age_days` (relative to `asOf`)
+   *
+   * Stored facts are not mutated. When `decayConfig.minEffectiveStrength > 0`,
+   * facts whose effective strength falls below the threshold are filtered
+   * out — this is how consumers ask "ignore stale facts" without changing
+   * the underlying data. Threshold defaults to 0 so back-compat is preserved.
+   *
    * @param {string} [asOf] - ISO date; defaults to now
-   * @returns {Array} Active beliefs
+   * @param {Object} [opts]
+   * @param {number} [opts.halfLifeDays] - Override instance half-life
+   * @param {number} [opts.minEffectiveStrength] - Override instance threshold
+   * @returns {Array} Active beliefs with `effective_strength` + `age_days`
    */
-  getActiveBeliefs(asOf) {
-    const ts = asOf ? new Date(asOf).getTime() : Date.now();
-    return this.user.beliefs.filter(b => {
-      const from = b.valid_from ? new Date(b.valid_from).getTime() : 0;
-      const to = b.valid_to ? new Date(b.valid_to).getTime() : Infinity;
-      return from <= ts && ts < to;
-    });
+  getActiveBeliefs(asOf, opts = {}) {
+    return this.#filterActive(this.user.beliefs, asOf, opts);
   }
 
   /**
@@ -513,9 +607,14 @@ export class KnowledgeGraph {
    * @param {string} type - Preference type (e.g., "content_style", "format", "tone")
    * @param {string} description - What the preference is
    * @param {number} strength - Preference strength (-1 to 1)
+   * @param {Object} [opts]
+   * @param {string} [opts.validFrom] - ISO date when this preference became
+   *   true (source date). Defaults to now.
+   * @param {string} [opts.episodeId] - Provenance pointer.
    */
-  addPreference(type, description, strength = 0.7) {
+  addPreference(type, description, strength = 0.7, opts = {}) {
     const now = new Date().toISOString();
+    const validFrom = opts.validFrom || now;
     const active = this.user.preferences.find(p =>
       p.type.toLowerCase() === type.toLowerCase() &&
       p.description.toLowerCase() === description.toLowerCase() &&
@@ -526,16 +625,20 @@ export class KnowledgeGraph {
       // Reinforce — update strength in place
       active.strength = Math.max(-1, Math.min(1, strength));
       active.recorded_at = now;
+      if (opts.episodeId) this.#linkEvidence(active, opts.episodeId);
       return;
     }
 
-    this.user.preferences.push({
+    const fact = {
       type, description,
       strength: Math.max(-1, Math.min(1, strength)),
-      valid_from: now,
+      valid_from: validFrom,
       valid_to: null,
-      recorded_at: now
-    });
+      recorded_at: now,
+      evidence: [],
+    };
+    if (opts.episodeId) this.#linkEvidence(fact, opts.episodeId);
+    this.user.preferences.push(fact);
   }
 
   /**
@@ -552,16 +655,15 @@ export class KnowledgeGraph {
 
   /**
    * Return all preferences that are currently active.
+   * Adds `effective_strength` + `age_days` the same way `getActiveBeliefs()`
+   * does; see that method for the decay semantics.
+   *
    * @param {string} [asOf] - ISO date; defaults to now
-   * @returns {Array} Active preferences
+   * @param {Object} [opts]
+   * @returns {Array} Active preferences with computed freshness fields
    */
-  getActivePreferences(asOf) {
-    const ts = asOf ? new Date(asOf).getTime() : Date.now();
-    return this.user.preferences.filter(p => {
-      const from = p.valid_from ? new Date(p.valid_from).getTime() : 0;
-      const to = p.valid_to ? new Date(p.valid_to).getTime() : Infinity;
-      return from <= ts && ts < to;
-    });
+  getActivePreferences(asOf, opts = {}) {
+    return this.#filterActive(this.user.preferences, asOf, opts);
   }
 
   /**
@@ -570,9 +672,14 @@ export class KnowledgeGraph {
    * @param {string} role - Identity role (e.g., "engineer", "founder", "investor")
    * @param {string} context - Context for this identity
    * @param {number} salience - How central this identity is (0-1)
+   * @param {Object} [opts]
+   * @param {string} [opts.validFrom] - ISO date when this identity became
+   *   true (source date). Defaults to now.
+   * @param {string} [opts.episodeId] - Provenance pointer.
    */
-  addIdentity(role, context = '', salience = 0.8) {
+  addIdentity(role, context = '', salience = 0.8, opts = {}) {
     const now = new Date().toISOString();
+    const validFrom = opts.validFrom || now;
     const active = this.user.identities.find(i =>
       i.role.toLowerCase() === role.toLowerCase() && !i.valid_to
     );
@@ -582,19 +689,243 @@ export class KnowledgeGraph {
         // Reinforce
         active.salience = Math.min(1, salience);
         active.recorded_at = now;
+        if (opts.episodeId) this.#linkEvidence(active, opts.episodeId);
         return;
       }
-      // Role context changed — close old
-      active.valid_to = now;
+      // Role context changed — close old, align to source timeline.
+      active.valid_to = validFrom;
     }
 
-    this.user.identities.push({
+    const fact = {
       role, context,
       salience: Math.min(1, salience),
-      valid_from: now,
+      valid_from: validFrom,
       valid_to: null,
-      recorded_at: now
-    });
+      recorded_at: now,
+      evidence: [],
+    };
+    if (opts.episodeId) this.#linkEvidence(fact, opts.episodeId);
+    this.user.identities.push(fact);
+  }
+
+  // ── Episodes (first-class source records) ──────────────
+
+  /**
+   * Record (or look up) a source episode. An episode is one concrete piece of
+   * input material — a chat conversation, a journal entry, an email thread —
+   * that facts can point back to via their `evidence: [episode_id]` array.
+   *
+   * Idempotent: if an episode with a matching `id` OR matching `content_hash`
+   * already exists, the existing one is returned. This lets the miner safely
+   * re-ingest the same file without creating duplicate episodes, and lets two
+   * different consumers converge on the same record when they happen to
+   * produce the same content.
+   *
+   * @param {Object} ep
+   * @param {string} [ep.id] - Consumer-supplied ID; auto-generated if omitted.
+   * @param {string} [ep.source='unknown'] - Free-form label (e.g. "chatgpt",
+   *   "gmail", "notes"). Consumers own the namespace.
+   * @param {string} [ep.source_date] - ISO date when the episode happened in
+   *   the real world. Null if unknown — fall back explicitly rather than
+   *   silently stamping "now".
+   * @param {string} [ep.content] - Raw text; hashed and summarised, not stored
+   *   verbatim (KGs are not blob stores).
+   * @param {string} [ep.content_summary] - Optional pre-computed summary.
+   * @param {Object} [ep.metadata] - Opaque consumer-side extras.
+   * @returns {Object} The canonical episode record.
+   */
+  addEpisode(ep = {}) {
+    if (!Array.isArray(this.user.episodes)) this.user.episodes = [];
+    const content = ep.content ?? '';
+    const content_hash = ep.content_hash || (content
+      ? createHash('sha256').update(content).digest('hex').slice(0, 16)
+      : null);
+    const now = new Date().toISOString();
+
+    // Dedup: prefer explicit id, fall back to hash. Returning the existing
+    // record (not a new one) lets callers repeatedly call addEpisode() during
+    // re-ingests without bloating the KG.
+    const existing = this.user.episodes.find(e =>
+      (ep.id && e.id === ep.id) ||
+      (content_hash && e.content_hash === content_hash)
+    );
+    if (existing) return existing;
+
+    const id = ep.id || `ep_${Date.now()}_${this.user.episodes.length}`;
+    const record = {
+      id,
+      source: ep.source || 'unknown',
+      source_date: ep.source_date || null,
+      ingested_at: now,
+      content_hash,
+      content_summary: ep.content_summary || (content ? content.slice(0, 200) : null),
+      ...(ep.metadata ? { metadata: ep.metadata } : {}),
+    };
+    this.user.episodes.push(record);
+    return record;
+  }
+
+  /**
+   * Look up an episode by id.
+   * @param {string} id
+   * @returns {Object|null}
+   */
+  getEpisode(id) {
+    return (this.user.episodes || []).find(e => e.id === id) || null;
+  }
+
+  /**
+   * Return the episode records that back a given fact — the provenance trail.
+   * Accepts either a fact object directly or a `{ type, topic }` selector.
+   *
+   * @param {Object} ref - `{ evidence: [...] }` or `{ type, topic }` or `{ type, role }`
+   * @returns {Array<Object>} Episode records in the order they were linked.
+   */
+  getFactProvenance(ref) {
+    if (!ref) return [];
+    let fact = ref;
+    if (!Array.isArray(ref.evidence) && (ref.type || ref.kind)) {
+      const type = ref.type || ref.kind;
+      const key = (ref.topic || ref.role || ref.type || '').toLowerCase();
+      const collection = type === 'belief' ? this.user.beliefs
+        : type === 'preference' ? this.user.preferences
+        : type === 'identity' ? this.user.identities
+        : [];
+      fact = collection.find(f => {
+        const k = (f.topic || f.type || f.role || '').toLowerCase();
+        return k === key && !f.valid_to;
+      });
+    }
+    if (!fact || !Array.isArray(fact.evidence)) return [];
+    return fact.evidence
+      .map(id => this.getEpisode(id))
+      .filter(Boolean);
+  }
+
+  #linkEvidence(fact, episodeId) {
+    if (!Array.isArray(fact.evidence)) fact.evidence = [];
+    if (!fact.evidence.includes(episodeId)) fact.evidence.push(episodeId);
+  }
+
+  /**
+   * Shared active-fact filter with temporal decay applied at read time.
+   * Used by `getActiveBeliefs/Preferences/Identities`.
+   *
+   * Decays `strength` (or `salience` for identities) with a half-life on
+   * `valid_from → asOf`. Returns shallow copies with `effective_strength`
+   * and `age_days` appended; the stored facts are never mutated. Callers
+   * who set `minEffectiveStrength > 0` get stale facts filtered out; the
+   * default threshold of 0 preserves pre-decay behaviour.
+   *
+   * @private
+   */
+  #filterActive(collection, asOf, opts = {}) {
+    const ts = asOf ? new Date(asOf).getTime() : Date.now();
+    const halfLife = opts.halfLifeDays ?? this.decayConfig.halfLifeDays;
+    const threshold = opts.minEffectiveStrength ?? this.decayConfig.minEffectiveStrength;
+    const halfLifeMs = halfLife * 86_400_000;
+    const results = [];
+
+    for (const fact of collection) {
+      const from = fact.valid_from ? new Date(fact.valid_from).getTime() : 0;
+      const to = fact.valid_to ? new Date(fact.valid_to).getTime() : Infinity;
+      if (!(from <= ts && ts < to)) continue;
+
+      // Base score: `strength` for beliefs/preferences, `salience` for
+      // identities. Fall back to 0.5 if neither is present (defensive).
+      const baseStrength = typeof fact.strength === 'number'
+        ? fact.strength
+        : (typeof fact.salience === 'number' ? fact.salience : 0.5);
+
+      // Age measured from the fact's source date, not ingest date — so
+      // imported-old facts age correctly. Negative ages (future-dated) are
+      // clamped to 0 so the decay term never exceeds 1.
+      const ageMs = Math.max(0, ts - from);
+      const effectiveStrength = halfLifeMs > 0
+        ? baseStrength * Math.pow(0.5, ageMs / halfLifeMs)
+        : baseStrength;
+
+      if (effectiveStrength < threshold) continue;
+
+      results.push({
+        ...fact,
+        effective_strength: effectiveStrength,
+        age_days: ageMs / 86_400_000,
+      });
+    }
+    return results;
+  }
+
+  // ── Reconciliation ─────────────────────────────────────
+
+  /**
+   * Sweep active facts and enforce cardinality on slots listed as "one" in
+   * the rules. For each such slot, keep only the newest active fact; every
+   * older one gets `valid_to` set to the newer fact's `valid_from` so the
+   * timeline reads as a clean handoff, not an overlap.
+   *
+   * Idempotent — re-running changes nothing when the graph is already
+   * reconciled. Safe to call after every ingest.
+   *
+   * Rule shape:
+   *   {
+   *     beliefs:     { [topic]: 'one' | 'many' },
+   *     preferences: { [type]:  'one' | 'many' },
+   *     identities:  { [role]:  'one' | 'many' }
+   *   }
+   *
+   * Only 'one' slots are acted on. Unlisted or 'many' slots keep their
+   * existing (possibly multiple) active facts untouched.
+   *
+   * @param {Object} [rules] - Rule map; defaults to `DEFAULT_RECONCILIATION_RULES`
+   * @returns {{ beliefs_invalidated: number, preferences_invalidated: number, identities_invalidated: number }}
+   */
+  reconcile(rules = DEFAULT_RECONCILIATION_RULES) {
+    const merged = {
+      beliefs: { ...(rules?.beliefs || {}) },
+      preferences: { ...(rules?.preferences || {}) },
+      identities: { ...(rules?.identities || {}) },
+    };
+
+    const sweep = (collection, ruleMap, keyFn) => {
+      // Bucket active facts by lowercase slot key. Only enforce on slots the
+      // consumer explicitly marked 'one'.
+      const buckets = new Map();
+      for (const fact of collection) {
+        if (fact.valid_to) continue;
+        const key = (keyFn(fact) || '').toLowerCase();
+        if (!key) continue;
+        const rule = ruleMap[key] || ruleMap[keyFn(fact)]; // exact-case fallback
+        if (rule !== 'one') continue;
+        if (!buckets.has(key)) buckets.set(key, []);
+        buckets.get(key).push(fact);
+      }
+
+      let invalidated = 0;
+      for (const group of buckets.values()) {
+        if (group.length < 2) continue;
+        // Sort by valid_from ascending, keep newest, close the rest at the
+        // newest's valid_from (so the timeline is a clean handoff).
+        group.sort((a, b) => {
+          const aT = a.valid_from ? new Date(a.valid_from).getTime() : 0;
+          const bT = b.valid_from ? new Date(b.valid_from).getTime() : 0;
+          return aT - bT;
+        });
+        const newest = group[group.length - 1];
+        for (const older of group.slice(0, -1)) {
+          older.valid_to = newest.valid_from || new Date().toISOString();
+          older.invalidation_reason = older.invalidation_reason || 'reconciled';
+          invalidated += 1;
+        }
+      }
+      return invalidated;
+    };
+
+    return {
+      beliefs_invalidated: sweep(this.user.beliefs, merged.beliefs, f => f.topic),
+      preferences_invalidated: sweep(this.user.preferences, merged.preferences, f => f.type),
+      identities_invalidated: sweep(this.user.identities, merged.identities, f => f.role),
+    };
   }
 
   /**
@@ -608,16 +939,14 @@ export class KnowledgeGraph {
 
   /**
    * Return all identities that are currently active.
+   * Adds `effective_strength` (derived from `salience`) and `age_days`.
+   *
    * @param {string} [asOf] - ISO date; defaults to now
-   * @returns {Array} Active identities
+   * @param {Object} [opts]
+   * @returns {Array} Active identities with computed freshness fields
    */
-  getActiveIdentities(asOf) {
-    const ts = asOf ? new Date(asOf).getTime() : Date.now();
-    return this.user.identities.filter(i => {
-      const from = i.valid_from ? new Date(i.valid_from).getTime() : 0;
-      const to = i.valid_to ? new Date(i.valid_to).getTime() : Infinity;
-      return from <= ts && ts < to;
-    });
+  getActiveIdentities(asOf, opts = {}) {
+    return this.#filterActive(this.user.identities, asOf, opts);
   }
 
   /**
@@ -991,11 +1320,12 @@ export class KnowledgeGraph {
       history: [],
       source_trust: {},
       // Layer 1: Typed Memory Nodes
-      beliefs: [],        // Core beliefs: { topic, claim, strength (0-1), evidence_count }
-      preferences: [],    // Explicit preferences: { type, description, strength (0-1) }
-      identities: [],     // Identity attributes: { role, context, salience (0-1) }
+      beliefs: [],        // Core beliefs: { topic, claim, strength (0-1), evidence_count, evidence: [episode_id] }
+      preferences: [],    // Explicit preferences: { type, description, strength (0-1), evidence: [episode_id] }
+      identities: [],     // Identity attributes: { role, context, salience (0-1), evidence: [episode_id] }
       confidence: {},     // Confidence by domain: { domain: confidence_score (0-1) }
-      clones: []          // UserClone hypothesis array
+      clones: [],         // UserClone hypothesis array
+      episodes: []        // Source records: { id, source, source_date, ingested_at, content_hash, content_summary?, metadata? }
     };
   }
 

--- a/scripts/bootstrap-alex.mjs
+++ b/scripts/bootstrap-alex.mjs
@@ -1,12 +1,20 @@
 #!/usr/bin/env node
 /**
- * bootstrap-alex.mjs — Seed Marble KG for Alex
+ * bootstrap-alex.mjs — Seed Marble KG for Alex via the public `Marble` API.
+ *
+ * Previous versions of this script went straight to `ConversationMiner` and
+ * `InvestigativeCommittee`, skipping `Marble.learn()` and the L1.5/L2/L3
+ * pipeline entirely. This rewrite drives everything through the lifecycle
+ * documented at the top of `core/index.js`:
+ *
+ *   init → ingestConversations / ingestEpisodes → learn → investigate → save
  *
  * Pipeline:
- *   Phase 1: ConversationMiner on all chat exports → thousands of raw nodes
- *   Phase 2: Inference pass on clusters → psychological patterns
- *   Phase 3: InvestigativeCommittee fills gaps with recursive follow-ups
- *   Phase 4: Cross-reference all beliefs → contradictions, clusters
+ *   Phase 0: Seed Alex's profile (interests, initial beliefs/prefs/identities)
+ *   Phase 1: Ingest ChatGPT exports via `marble.ingestConversations()`
+ *   Phase 2: Ingest Claude memory + GitHub READMEs as generic episodes
+ *   Phase 3: `marble.learn()` — L1.5 swarm, L2 inference, L3 clone evolution
+ *   Phase 4: `marble.investigate()` — adaptive committee fills gaps
  *
  * Usage:
  *   node scripts/bootstrap-alex.mjs
@@ -17,13 +25,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-// glob requires Node 22+; use readdirSync fallback for Node 20
-const glob = async (pattern) => {
-  const dir = path.dirname(pattern.replace(/\*.*/, ''));
-  if (!fs.existsSync(dir)) return [];
-  const ext = pattern.match(/\*(\.\w+)$/)?.[1] || '';
-  return fs.readdirSync(dir).filter(f => !ext || f.endsWith(ext)).map(f => path.join(dir, f));
-};
+import { Marble } from '../core/index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -61,7 +63,6 @@ async function llmCall(prompt) {
       }
 
       const j = await res.json();
-      // Ollama format: data.message.content
       const content = j.message?.content || j.choices?.[0]?.message?.content || '';
       if (!content) throw new Error('Empty LLM response');
       return content;
@@ -78,32 +79,61 @@ async function llmCall(prompt) {
   }
 }
 
-// ── Data sources ─────────────────────────────────────────────────────────
+// ── Data gathering ─────────────────────────────────────────────────────
 
-// Claude memory files (all projects)
-function findClaudeMemory() {
+/**
+ * Walk `~/.claude/projects/*/memory/*.md` and return episode-shaped objects
+ * ready for `marble.ingestEpisodes()`. One episode per memory file; source
+ * date reads the file's mtime rather than substituting "now".
+ */
+function gatherClaudeMemory() {
   const baseDir = path.join(HOME, '.claude', 'projects');
   const results = [];
   if (!fs.existsSync(baseDir)) return results;
-  try {
-    const projects = fs.readdirSync(baseDir);
-    for (const proj of projects) {
-      const memDir = path.join(baseDir, proj, 'memory');
-      if (fs.existsSync(memDir)) {
-        const files = fs.readdirSync(memDir).filter(f => f.endsWith('.md'));
-        for (const file of files) {
-          try {
-            results.push({ file: `claude:${proj}/${file}`, content: fs.readFileSync(path.join(memDir, file), 'utf8') });
-          } catch { /* skip */ }
-        }
-      }
+  for (const proj of fs.readdirSync(baseDir)) {
+    const memDir = path.join(baseDir, proj, 'memory');
+    if (!fs.existsSync(memDir)) continue;
+    for (const file of fs.readdirSync(memDir).filter(f => f.endsWith('.md'))) {
+      const full = path.join(memDir, file);
+      try {
+        const content = fs.readFileSync(full, 'utf8');
+        const stat = fs.statSync(full);
+        results.push({
+          id: `claude:${proj}/${file}`,
+          source: 'claude-memory',
+          source_date: stat.mtime.toISOString(),
+          content,
+          metadata: { project: proj, file },
+        });
+      } catch { /* skip unreadable files */ }
     }
-  } catch { /* skip */ }
+  }
   return results;
 }
 
-// ChatGPT exports
-function findChatGPTExports() {
+function gatherGitHubReadmes() {
+  const ghDir = path.join(HOME, 'Documents', 'GitHub');
+  const results = [];
+  if (!fs.existsSync(ghDir)) return results;
+  for (const repo of fs.readdirSync(ghDir)) {
+    const readme = path.join(ghDir, repo, 'README.md');
+    if (!fs.existsSync(readme)) continue;
+    try {
+      const content = fs.readFileSync(readme, 'utf8');
+      const stat = fs.statSync(readme);
+      results.push({
+        id: `github:${repo}/README.md`,
+        source: 'github-readme',
+        source_date: stat.mtime.toISOString(),
+        content,
+        metadata: { repo },
+      });
+    } catch { /* skip */ }
+  }
+  return results;
+}
+
+function gatherChatGPTExports() {
   const dlDir = path.join(HOME, 'Downloads');
   if (!fs.existsSync(dlDir)) return [];
   return fs.readdirSync(dlDir)
@@ -111,64 +141,33 @@ function findChatGPTExports() {
     .map(f => path.join(dlDir, f));
 }
 
-// GitHub READMEs
-function findGitHubReadmes() {
-  const ghDir = path.join(HOME, 'Documents', 'GitHub');
-  const results = [];
-  if (!fs.existsSync(ghDir)) return results;
-  try {
-    const repos = fs.readdirSync(ghDir);
-    for (const repo of repos) {
-      const readme = path.join(ghDir, repo, 'README.md');
-      if (fs.existsSync(readme)) {
-        try {
-          results.push({ file: `github:${repo}/README.md`, content: fs.readFileSync(readme, 'utf8') });
-        } catch { /* skip */ }
-      }
-    }
-  } catch { /* skip */ }
-  return results;
-}
-
-function readDirText(dir, maxFiles = 50) {
-  const results = [];
-  if (!fs.existsSync(dir)) return results;
-  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.txt')).slice(0, maxFiles);
-  for (const file of files) {
-    try {
-      results.push({ file, content: fs.readFileSync(path.join(dir, file), 'utf8') });
-    } catch { /* skip */ }
-  }
-  return results;
-}
-
+/**
+ * Build a registerSource()-compatible search function over a list of raw
+ * documents. Used to give the InvestigativeCommittee evidence to query.
+ */
 function buildSearchFn(documents) {
   return async (query) => {
     const q = query.toLowerCase();
     const hits = [];
-    for (const { file, content } of documents) {
+    for (const { content, id } of documents) {
       const words = q.split(/\s+/).filter(w => w.length > 3);
       const matches = words.filter(w => content.toLowerCase().includes(w));
-      if (matches.length > 0) {
-        // For strong matches (3+ keywords), return full content (capped at 2000 chars)
-        if (matches.length >= 3) {
-          hits.push(`[${file}] ${content.slice(0, 2000)}`);
-        } else {
-          const lines = content.split('\n');
-          const relevant = lines.filter(l => matches.some(w => l.toLowerCase().includes(w)));
-          hits.push(`[${file}] ${relevant.slice(0, 8).join(' | ')}`);
-        }
+      if (matches.length === 0) continue;
+      if (matches.length >= 3) {
+        hits.push(`[${id}] ${content.slice(0, 2000)}`);
+      } else {
+        const lines = content.split('\n');
+        const relevant = lines.filter(l => matches.some(w => l.toLowerCase().includes(w)));
+        hits.push(`[${id}] ${relevant.slice(0, 8).join(' | ')}`);
       }
     }
     return hits.slice(0, 12);
   };
 }
 
-// ── Seed facts ────────────────────────────────────────────────────────────
+// ── Alex seed ─────────────────────────────────────────────────────────
 
 const ALEX_SEED = {
-  id: 'alex',
-  dob: '1988-11-02',
   interests: [
     { topic: 'LLMs / Generative AI', weight: 0.92, trend: 'rising' },
     { topic: 'AI Agents & Orchestration', weight: 0.91, trend: 'rising' },
@@ -182,243 +181,164 @@ const ALEX_SEED = {
     { topic: 'Fitness & Biohacking', weight: 0.65, trend: 'rising' },
     { topic: 'Logistics & Trade', weight: 0.55, trend: 'stable' },
     { topic: 'Crypto / Web3', weight: 0.45, trend: 'stable' },
-  ].map(i => ({ ...i, last_boost: new Date().toISOString() })),
+  ],
   context: {
-    calendar: [],
     active_projects: ['AhaRoll', 'SuperstateX', 'BooRadar', 'Vivo', 'Marble'],
-    recent_conversations: [],
-    mood_signal: null,
     location: 'Barcelona',
   },
-  history: [],
-  source_trust: {},
   beliefs: [
-    { topic: 'building', claim: 'Ship fast, learn from real users — not from planning', strength: 0.9, evidence_count: 1, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
-    { topic: 'AI', claim: 'AI agents will replace most solo founder execution within 2 years', strength: 0.85, evidence_count: 1, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
+    { topic: 'building', claim: 'Ship fast, learn from real users — not from planning', strength: 0.9 },
+    { topic: 'AI', claim: 'AI agents will replace most solo founder execution within 2 years', strength: 0.85 },
   ],
   preferences: [
-    { type: 'work_style', description: 'Prefers systems thinking + delegation over manual execution', strength: 0.85, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
-    { type: 'content', description: 'Direct, no-fluff communication — skips pleasantries', strength: 0.9, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
+    { type: 'work_style', description: 'Prefers systems thinking + delegation over manual execution', strength: 0.85 },
+    { type: 'content', description: 'Direct, no-fluff communication — skips pleasantries', strength: 0.9 },
   ],
   identities: [
-    { role: 'multi-venture founder', context: 'Barcelona, 5-month runway', salience: 1.0, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
-    { role: 'builder', context: 'AI tools, consumer apps', salience: 0.9, valid_from: new Date().toISOString(), valid_to: null, recorded_at: new Date().toISOString() },
+    { role: 'multi-venture founder', context: 'Barcelona, 5-month runway', salience: 1.0 },
+    { role: 'builder', context: 'AI tools, consumer apps', salience: 0.9 },
   ],
   confidence: { AI: 0.9, marketing: 0.75, logistics: 0.6, coaching: 0.65 },
-  clones: [],
 };
+
+/**
+ * Apply the seed to a freshly-initialised KG. Skips if the KG already has
+ * beliefs — that way re-running bootstrap over an existing file only adds
+ * new episodes and doesn't replay the seed.
+ */
+function applySeed(marble) {
+  const kg = marble.kg;
+  if ((kg.user.beliefs || []).length > 0) return false;
+
+  kg.user.id = 'alex';
+  kg.user.context = { ...(kg.user.context || {}), ...ALEX_SEED.context };
+  kg.user.confidence = { ...(kg.user.confidence || {}), ...ALEX_SEED.confidence };
+
+  const now = new Date().toISOString();
+  kg.user.interests = ALEX_SEED.interests.map(i => ({ ...i, last_boost: now }));
+
+  for (const b of ALEX_SEED.beliefs) {
+    kg.addBelief(b.topic, b.claim, b.strength);
+  }
+  for (const p of ALEX_SEED.preferences) {
+    kg.addPreference(p.type, p.description, p.strength);
+  }
+  for (const id of ALEX_SEED.identities) {
+    kg.addIdentity(id.role, id.context, id.salience);
+  }
+  return true;
+}
 
 // ── Main ──────────────────────────────────────────────────────────────────
 
 async function main() {
   console.log('=== Marble Bootstrap: Alex ===\n');
 
-  // ── Phase 0: Gather data sources ──────────────────────
-  const claudeMemory = findClaudeMemory();
-  const chatGPTExports = findChatGPTExports();
-  const githubReadmes = findGitHubReadmes();
+  const marble = new Marble({ storage: KG_PATH, llm: llmCall, silent: true });
+  await marble.init();
 
-  console.log(`Data sources found:`);
+  const seeded = applySeed(marble);
+  console.log(seeded ? '✓ Seeded fresh KG with Alex\'s profile' : '→ Reusing existing KG (skipping seed)');
+
+  // ── Phase 0: Data gathering ──────────────────────────────
+  const claudeMemory = gatherClaudeMemory();
+  const chatGPTExports = gatherChatGPTExports();
+  const githubReadmes = gatherGitHubReadmes();
+
+  console.log('\nData sources found:');
   console.log(`  Claude memory files: ${claudeMemory.length}`);
   console.log(`  ChatGPT export files: ${chatGPTExports.length}`);
   console.log(`  GitHub READMEs: ${githubReadmes.length}`);
 
-  const allDocs = [...claudeMemory, ...githubReadmes];
-  const searchFn = buildSearchFn(allDocs);
-
-  // Initialise KG with seed
-  const kgData = {
-    user: ALEX_SEED,
-    _dimensionalPreferences: [],
-    updated_at: new Date().toISOString(),
-  };
-
-  // KG proxy that maps to real field names
-  const kgProxy = {
-    user: kgData.user,
-    getActiveBeliefs: () => kgData.user.beliefs.filter(b => !b.valid_to),
-    getActivePreferences: () => kgData.user.preferences.filter(p => !p.valid_to),
-    getActiveIdentities: () => kgData.user.identities.filter(i => !i.valid_to),
-    getDimensionalPreferences: () => kgData._dimensionalPreferences || [],
-    getInterestWeight: (topic) => {
-      const i = kgData.user.interests.find(x => x.topic.toLowerCase() === topic.toLowerCase());
-      return i ? i.weight : 0;
-    },
-    addBelief: (topic, claim, strength = 0.75) => {
-      const now = new Date().toISOString();
-      kgData.user.beliefs.push({ topic, claim, strength, evidence_count: 1, valid_from: now, valid_to: null, recorded_at: now });
-    },
-    addPreference: (type, description, strength = 0.7) => {
-      const now = new Date().toISOString();
-      kgData.user.preferences.push({ type, description, strength, valid_from: now, valid_to: null, recorded_at: now });
-    },
-    addIdentity: (role, context = '', salience = 0.7) => {
-      const now = new Date().toISOString();
-      kgData.user.identities.push({ role, context, salience, valid_from: now, valid_to: null, recorded_at: now });
-    },
-    tagEmotions: (type, topic, emotions) => {
-      const topicLower = topic.toLowerCase();
-      let collection;
-      if (type === 'belief') collection = kgData.user.beliefs;
-      else if (type === 'preference') collection = kgData.user.preferences;
-      else if (type === 'identity') collection = kgData.user.identities;
-      else return;
-      for (const item of collection) {
-        const key = item.topic || item.type || item.role || '';
-        if (key.toLowerCase() === topicLower && !item.valid_to) {
-          item.emotions = [...new Set([...(item.emotions || []), ...emotions])];
-        }
-      }
-    },
-  };
-
-  // ── Phase 1: Mine conversations ──────────────────────────
+  // ── Phase 1: Ingest ChatGPT exports ───────────────────────
   if (chatGPTExports.length > 0) {
-    console.log('\n── Phase 1: Mining conversations ──');
-    const { ConversationMiner } = await import('../core/conversation-miner.js');
-    const miner = new ConversationMiner(llmCall, {
-      chunkSize: 20,
-      onProgress: (stats) => {
-        if (stats.phase === 'extract') {
-          console.log(`    chunk ${stats.chunksProcessed} → ${stats.nodesExtracted} nodes total`);
-        }
-        if (stats.phase === 'infer') {
-          console.log(`    inference batch ${stats.inferBatch} → ${stats.inferencesGenerated} inferences`);
-        }
-      },
-    });
-
-    let totalStats = { ingested: 0, beliefs: 0, preferences: 0, identities: 0, inferences: 0, duplicates_merged: 0 };
-
+    console.log('\n── Phase 1: Ingesting ChatGPT exports ──');
     for (const exportPath of chatGPTExports) {
       console.log(`\n  Processing: ${path.basename(exportPath)}`);
       try {
-        const stats = await miner.ingestIntoKG(exportPath, kgProxy, { exchangeMode: false, runInference: true });
-        totalStats.ingested += stats.ingested;
-        totalStats.beliefs += stats.beliefs;
-        totalStats.preferences += stats.preferences;
-        totalStats.identities += stats.identities;
-        totalStats.inferences += stats.inferences;
-        totalStats.duplicates_merged += stats.duplicates_merged;
-        console.log(`    → ${stats.ingested} nodes (${stats.beliefs}b/${stats.preferences}p/${stats.identities}i), ${stats.inferences} inferences, ${stats.duplicates_merged} dupes merged`);
+        const stats = await marble.ingestConversations(exportPath, {
+          exchangeMode: false,
+          runInference: true,
+          sourceLabel: 'chatgpt-export',
+          onProgress: (s) => {
+            if (s.phase === 'extract' && s.chunksProcessed && s.chunksProcessed % 10 === 0) {
+              console.log(`    chunk ${s.chunksProcessed} → ${s.nodesExtracted} nodes`);
+            }
+          },
+        });
+        console.log(`    → ${stats.ingested} nodes (${stats.beliefs}b/${stats.preferences}p/${stats.identities}i), ${stats.inferences} inferences, ${stats.episodes} episodes`);
+        if (stats.reconciled && (stats.reconciled.beliefs_invalidated + stats.reconciled.preferences_invalidated + stats.reconciled.identities_invalidated) > 0) {
+          console.log(`    reconciled: ${JSON.stringify(stats.reconciled)}`);
+        }
       } catch (err) {
         console.warn(`    ✗ Failed: ${err.message}`);
       }
     }
-
-    console.log(`\n  Phase 1 total: ${totalStats.ingested} nodes ingested, ${totalStats.inferences} inferences`);
-    console.log(`  KG now has: ${kgData.user.beliefs.length} beliefs, ${kgData.user.preferences.length} prefs, ${kgData.user.identities.length} identities`);
   } else {
     console.log('\n[skip] No ChatGPT exports found in ~/Downloads/');
   }
 
-  // ── Phase 2: Mine Claude memory ──────────────────────────
-  if (claudeMemory.length > 0) {
-    console.log('\n── Phase 2: Mining Claude memory files ──');
-    for (const { file, content } of claudeMemory) {
-      // Direct extraction from structured memory files (simpler than conversation mining)
-      try {
-        const prompt = `Extract knowledge graph nodes from this AI assistant memory file about a user.
-
-File: ${file}
-Content:
-${content.slice(0, 3000)}
-
-Return ONLY a JSON array:
-[{ "type": "belief"|"preference"|"identity", "value": "statement about user", "confidence": 0.7-0.9, "topic": "category" }]`;
-
-        const raw = await llmCall(prompt);
-        const nodes = parseNodesFromRaw(raw);
-        for (const node of nodes) {
-          if (node.type === 'belief' || node.type === 'decision') kgProxy.addBelief(node.topic, node.value, node.confidence);
-          else if (node.type === 'preference') kgProxy.addPreference(node.topic, node.value, node.confidence);
-          else if (node.type === 'identity') kgProxy.addIdentity(node.topic, node.value, node.confidence);
-        }
-        if (nodes.length > 0) console.log(`  ${file}: ${nodes.length} nodes`);
-      } catch (err) {
-        console.warn(`  ${file}: failed (${err.message})`);
-      }
+  // ── Phase 2: Ingest Claude memory + GitHub READMEs as generic episodes ──
+  const docEpisodes = [...claudeMemory, ...githubReadmes];
+  if (docEpisodes.length > 0) {
+    console.log(`\n── Phase 2: Ingesting ${docEpisodes.length} generic episodes ──`);
+    try {
+      const stats = await marble.ingestEpisodes(docEpisodes, { runInference: true });
+      console.log(`  → ${stats.ingested} nodes, ${stats.inferences} inferences, ${stats.episodes} episodes`);
+    } catch (err) {
+      console.warn(`  ✗ Failed: ${err.message}`);
     }
-    console.log(`  KG now has: ${kgData.user.beliefs.length} beliefs, ${kgData.user.preferences.length} prefs, ${kgData.user.identities.length} identities`);
   }
 
-  // ── Phase 3: Investigative Committee fills gaps ──────────
-  console.log('\n── Phase 3: Investigative Committee (gap-filling) ──');
+  console.log(`\n  KG state: ${marble.kg.user.beliefs.length} beliefs, ${marble.kg.user.preferences.length} prefs, ${marble.kg.user.identities.length} identities, ${marble.kg.user.episodes.length} episodes`);
 
-  const { InvestigativeCommittee } = await import('../core/investigative-committee.js');
-
-  const MAX_ROUNDS = parseInt(process.env.ROUNDS || '2');
-  const committee = new InvestigativeCommittee(kgProxy, llmCall, {
-    maxRounds: MAX_ROUNDS,
-    maxQuestionsPerRound: 4,
-    maxFollowUpsPerFinding: 2,
-    enableDebate: true,
-    enablePsychInference: true,
-    enableCrossRef: true,
-  });
-
-  // Register all document sources for evidence search
-  committee.registerSource('claude-memory', buildSearchFn(claudeMemory));
-  committee.registerSource('github-readmes', buildSearchFn(githubReadmes));
-
-  console.log(`  Running ${MAX_ROUNDS} round(s) with ${kgData.user.beliefs.length} beliefs as starting context...\n`);
+  // ── Phase 3: learn() — L1.5 swarm, L2 inference, L3 clone evolution ──
+  console.log('\n── Phase 3: marble.learn() ──');
   try {
-    const result = await committee.investigate(MAX_ROUNDS);
-    console.log(`\n  Investigation complete:`);
-    console.log(`    Questions answered: ${result.answered}`);
-    console.log(`    Knowledge gaps: ${result.gaps.length}`);
-    console.log(`    Psych inferences: ${result.psychInferences?.length || 0}`);
-    console.log(`    Committee: ${result.committee?.map(c => c.name).join(', ') || '(fallback)'}`);
-
-    if (result.crossRefResults) {
-      console.log(`    Contradictions: ${result.crossRefResults.contradictions?.length || 0}`);
-      console.log(`    Clusters: ${result.crossRefResults.clusters?.length || 0}`);
-    }
-
-    if (result.gaps.length) {
-      console.log('\n  Knowledge gaps (for clone hypotheses):');
-      result.gaps.slice(0, 10).forEach((g, i) => console.log(`    ${i + 1}. ${g}`));
+    const learnResult = await marble.learn();
+    console.log(`  insights: ${learnResult.insights}, candidates: ${learnResult.candidates}, clones: ${learnResult.clones}`);
+    console.log(`  stages: ${JSON.stringify(learnResult.stages)}`);
+    if (learnResult.failures.length > 0) {
+      console.warn(`  failures: ${learnResult.failures.map(f => `${f.stage}:${f.message}`).join(' | ')}`);
     }
   } catch (err) {
-    console.error('  Investigation error:', err.message);
-    console.log('  Continuing with mined data...');
+    console.warn(`  learn() failed: ${err.message}`);
+  }
+
+  // ── Phase 4: investigate() — committee fills gaps ───────
+  console.log('\n── Phase 4: marble.investigate() ──');
+  const MAX_ROUNDS = parseInt(process.env.ROUNDS || '2');
+  try {
+    const result = await marble.investigate({
+      maxRounds: MAX_ROUNDS,
+      sources: {
+        'claude-memory': buildSearchFn(claudeMemory),
+        'github-readmes': buildSearchFn(githubReadmes),
+      },
+    });
+    console.log(`  answered: ${result.answered || 0}, gaps: ${result.gaps?.length || 0}, psychInferences: ${result.psychInferences?.length || 0}`);
+    if (result.gaps?.length) {
+      console.log('  Top gaps:');
+      result.gaps.slice(0, 5).forEach((g, i) => console.log(`    ${i + 1}. ${g}`));
+    }
+  } catch (err) {
+    console.warn(`  investigate() failed: ${err.message}`);
   }
 
   // ── Save ────────────────────────────────────────────────
   if (DRY_RUN) {
     console.log('\n[dry-run] KG not saved.');
-    console.log(`  Would save: ${kgData.user.beliefs.length} beliefs, ${kgData.user.preferences.length} prefs, ${kgData.user.identities.length} identities`);
     return;
   }
 
-  fs.mkdirSync(path.join(ROOT, 'data', 'kg'), { recursive: true });
-  fs.writeFileSync(KG_PATH, JSON.stringify(kgData, null, 2));
+  fs.mkdirSync(path.dirname(KG_PATH), { recursive: true });
+  await marble.save();
   console.log(`\n✓ KG saved to ${KG_PATH}`);
-  console.log(`  Beliefs: ${kgData.user.beliefs.length}`);
-  console.log(`  Preferences: ${kgData.user.preferences.length}`);
-  console.log(`  Identities: ${kgData.user.identities.length}`);
-  console.log(`  Clones: ${kgData.user.clones.length}`);
-}
-
-// Helper for raw LLM response parsing (used in Phase 2)
-function parseNodesFromRaw(responseText) {
-  let text = responseText.trim();
-  text = text.replace(/^```(?:json)?\s*/i, '').replace(/\s*```\s*$/, '');
-  const start = text.indexOf('[');
-  const end = text.lastIndexOf(']');
-  if (start === -1 || end === -1) return [];
-  try {
-    const nodes = JSON.parse(text.slice(start, end + 1));
-    if (!Array.isArray(nodes)) return [];
-    return nodes.filter(n => n && n.type && n.value).map(n => ({
-      type: String(n.type).toLowerCase(),
-      value: String(n.value).trim(),
-      confidence: Math.max(0, Math.min(1, parseFloat(n.confidence) || 0.6)),
-      topic: String(n.topic || n.type).trim(),
-    }));
-  } catch {
-    return [];
-  }
+  console.log(`  Beliefs: ${marble.kg.user.beliefs.length}`);
+  console.log(`  Preferences: ${marble.kg.user.preferences.length}`);
+  console.log(`  Identities: ${marble.kg.user.identities.length}`);
+  console.log(`  Episodes: ${marble.kg.user.episodes.length}`);
+  console.log(`  Clones: ${marble.kg.user.clones?.length || 0}`);
 }
 
 main().catch(console.error);

--- a/test/temporal-truth.test.js
+++ b/test/temporal-truth.test.js
@@ -1,0 +1,182 @@
+/**
+ * temporal-truth.test.js — PR 1 acceptance: episodes, source timestamps,
+ * reconciliation, and read-time decay.
+ *
+ * Covers the four changes of "Temporal truth v1":
+ *   1. `valid_from` stamped with source date, not extraction date
+ *   2. Episodes are first-class and facts carry `evidence: [episode_id]`
+ *   3. Reconciliation closes superseded facts on single-cardinality slots
+ *   4. `getActiveX()` computes `effective_strength` + `age_days`, filters by
+ *      threshold, and historical queries still return old facts
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { writeFile, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Marble, KnowledgeGraph, KG_VERSION } from '../core/index.js';
+
+function mockLLMWithResponses(responses) {
+  let i = 0;
+  return async () => responses[i++] ?? '[]';
+}
+
+describe('episodes + source timestamps', () => {
+  it('KnowledgeGraph.addEpisode stores and dedups by content hash', async () => {
+    const kg = new KnowledgeGraph(join(tmpdir(), `marble-temporal-${Date.now()}-a.json`));
+    await kg.load();
+
+    const a = kg.addEpisode({ source: 'test', source_date: '2022-01-01T00:00:00Z', content: 'Hello world' });
+    const b = kg.addEpisode({ source: 'test', source_date: '2022-01-01T00:00:00Z', content: 'Hello world' });
+    assert.equal(a.id, b.id, 'same content → dedup returns same record');
+    assert.equal(kg.user.episodes.length, 1);
+    assert.equal(kg.version, KG_VERSION);
+  });
+
+  it('addBelief({ validFrom, episodeId }) threads source time + provenance', async () => {
+    const kg = new KnowledgeGraph(join(tmpdir(), `marble-temporal-${Date.now()}-b.json`));
+    await kg.load();
+
+    const ep = kg.addEpisode({ source: 'test', source_date: '2020-06-01T00:00:00Z', content: 'Source material' });
+    kg.addBelief('work', 'loves ai', 0.8, { validFrom: '2020-06-01T00:00:00Z', episodeId: ep.id });
+
+    const b = kg.getActiveBeliefs()[0];
+    assert.equal(b.valid_from, '2020-06-01T00:00:00Z', 'valid_from is the source date');
+    assert.deepEqual(b.evidence, [ep.id], 'evidence points back to episode');
+
+    const prov = kg.getFactProvenance(b);
+    assert.equal(prov.length, 1);
+    assert.equal(prov[0].id, ep.id);
+  });
+
+  it('contradiction closure uses source date, not wall-clock', async () => {
+    const kg = new KnowledgeGraph(join(tmpdir(), `marble-temporal-${Date.now()}-c.json`));
+    await kg.load();
+
+    kg.addBelief('role', 'engineer', 0.9, { validFrom: '2019-01-01T00:00:00Z' });
+    kg.addBelief('role', 'founder', 0.9, { validFrom: '2023-01-01T00:00:00Z' });
+
+    const history = kg.getFactHistory('belief', 'role');
+    assert.equal(history.length, 2);
+    assert.equal(history[0].valid_to, '2023-01-01T00:00:00Z',
+      'old fact is closed at the new fact\'s source date, not now()');
+  });
+});
+
+describe('ingestEpisodes end-to-end', () => {
+  it('creates episodes, stamps valid_from, links evidence', async () => {
+    const storage = join(tmpdir(), `marble-temporal-${Date.now()}-d.json`);
+    const marble = new Marble({
+      storage,
+      llm: mockLLMWithResponses([
+        JSON.stringify([{ type: 'belief', value: 'User journals daily', confidence: 0.9, topic: 'habit_journal' }]),
+        JSON.stringify([{ type: 'identity', value: 'Lives in Barcelona', confidence: 0.95, topic: 'current_city' }]),
+      ]),
+      silent: true,
+    });
+    await marble.init();
+
+    const stats = await marble.ingestEpisodes([
+      { id: 'ep-a', source: 'journal', source_date: '2023-03-15T00:00:00Z', content: 'I journal every evening.' },
+      { id: 'ep-b', source: 'notes', source_date: '2024-07-01T00:00:00Z', content: 'Life in Barcelona is good.' },
+    ], { runInference: false });
+
+    assert.equal(stats.episodes, 2);
+    assert.equal(stats.ingested, 2);
+
+    const b = marble.kg.getActiveBeliefs().find(x => x.topic === 'habit_journal');
+    assert.ok(b);
+    assert.equal(b.valid_from, '2023-03-15T00:00:00Z');
+    assert.deepEqual(b.evidence, ['ep-a']);
+
+    const i = marble.kg.getActiveIdentities().find(x => x.role === 'current_city');
+    assert.ok(i);
+    assert.equal(i.valid_from, '2024-07-01T00:00:00Z');
+    assert.deepEqual(i.evidence, ['ep-b']);
+
+    await unlink(storage).catch(() => {});
+  });
+});
+
+describe('reconciliation on single-cardinality slots', () => {
+  it('collapses multiple active preferences on a one-cardinality slot', async () => {
+    const kg = new KnowledgeGraph(join(tmpdir(), `marble-temporal-${Date.now()}-e.json`));
+    await kg.load();
+
+    kg.addPreference('primary_diet', 'vegetarian', 0.9, { validFrom: '2020-01-01T00:00:00Z' });
+    kg.addPreference('primary_diet', 'omnivore', 0.9, { validFrom: '2024-01-01T00:00:00Z' });
+    // Before reconcile: both active (preferences don't auto-close on same type + different description).
+    assert.equal(kg.getActivePreferences().length, 2);
+
+    const result = kg.reconcile({ preferences: { primary_diet: 'one' } });
+    assert.equal(result.preferences_invalidated, 1);
+    assert.equal(kg.getActivePreferences().length, 1);
+    const surviving = kg.getActivePreferences()[0];
+    assert.equal(surviving.description, 'omnivore');
+  });
+
+  it('respects asOf for historical queries after reconcile', async () => {
+    const kg = new KnowledgeGraph(join(tmpdir(), `marble-temporal-${Date.now()}-f.json`));
+    await kg.load();
+
+    kg.addIdentity('current_city', 'Barcelona', 0.9, { validFrom: '2019-01-01T00:00:00Z' });
+    kg.addIdentity('current_city', 'Lisbon', 0.9, { validFrom: '2024-01-01T00:00:00Z' });
+    kg.reconcile({ identities: { current_city: 'one' } });
+
+    const nowActive = kg.getActiveIdentities();
+    assert.equal(nowActive.length, 1);
+    assert.equal(nowActive[0].context, 'Lisbon');
+
+    const at2020 = kg.getActiveIdentities('2020-06-01T00:00:00Z');
+    assert.equal(at2020.length, 1);
+    assert.equal(at2020[0].context, 'Barcelona',
+      'historical query still finds the old fact');
+  });
+});
+
+describe('temporal decay at read time', () => {
+  it('computes effective_strength and age_days without mutating facts', async () => {
+    const kg = new KnowledgeGraph(
+      join(tmpdir(), `marble-temporal-${Date.now()}-g.json`),
+      { decayConfig: { halfLifeDays: 365, minEffectiveStrength: 0 } }
+    );
+    await kg.load();
+
+    const oneYearAgo = new Date(Date.now() - 365 * 86400000).toISOString();
+    kg.addBelief('opinion', 'claim', 0.8, { validFrom: oneYearAgo });
+
+    const active = kg.getActiveBeliefs();
+    assert.equal(active.length, 1);
+    assert.ok(active[0].age_days >= 364 && active[0].age_days <= 366);
+    // One half-life → effective strength ~= 0.4
+    assert.ok(Math.abs(active[0].effective_strength - 0.4) < 0.01);
+
+    // Underlying stored fact is not mutated
+    const stored = kg.user.beliefs[0];
+    assert.equal(stored.effective_strength, undefined);
+    assert.equal(stored.strength, 0.8);
+  });
+
+  it('filters below threshold; historical query still returns', async () => {
+    const kg = new KnowledgeGraph(
+      join(tmpdir(), `marble-temporal-${Date.now()}-h.json`),
+      { decayConfig: { halfLifeDays: 365, minEffectiveStrength: 0.1 } }
+    );
+    await kg.load();
+
+    const fiveYearsAgo = new Date(Date.now() - 5 * 365 * 86400000).toISOString();
+    kg.addBelief('old', 'claim', 0.5, { validFrom: fiveYearsAgo });
+    // 5 half-lives: 0.5 * 2^-5 = 0.015625 < 0.1 threshold
+    assert.equal(kg.getActiveBeliefs().length, 0, 'stale fact filtered out at default threshold');
+
+    // Overriding threshold returns it
+    const withZero = kg.getActiveBeliefs(null, { minEffectiveStrength: 0 });
+    assert.equal(withZero.length, 1);
+
+    // Historical query at creation time: effective strength is full
+    const atCreation = kg.getActiveBeliefs(fiveYearsAgo, { minEffectiveStrength: 0 });
+    assert.equal(atCreation.length, 1);
+    assert.ok(atCreation[0].effective_strength >= 0.49);
+  });
+});


### PR DESCRIPTION
Addresses the **P0 correctness** bucket from the user-run feedback. This is the bundled "Temporal truth v1" PR: one change set that makes the existing temporal machinery work correctly end to end.

## What changed

**Schema (KG)**
- `kg.version` + forward-migration hook (v0 → v1 adds `user.episodes[]`)
- `user.episodes[]` is now first-class: `addEpisode / getEpisode / getFactProvenance`
- Every fact carries `evidence: [episode_id]` (alongside `evidence_count`)

**Source timestamps**
- `ConversationMiner` reads real source dates (`conv.create_time` on ChatGPT, `created_at` on Claude, per-message fallback)
- `addBelief/addPreference/addIdentity` accept `{ validFrom, episodeId }`; contradiction closures use the source date, not wall-clock
- `valid_from` = source date, not ingest date — temporal queries now work

**Generic episode ingestion**
- New `marble.ingestEpisodes(episodes[])`: consumer-owned adapters can produce `{ id?, source, source_date, content, metadata? }` and hand it over. No more ChatGPT-only first-class path.
- `ingestConversations` becomes a thin chat-format wrapper over the same pipeline

**Reconciliation**
- `reconciliationRules` constructor option (`{ beliefs/preferences/identities: { slot: 'one'|'many' } }`)
- `kg.reconcile()` batch pass closes superseded facts on 'one' slots; unlisted = 'many' (no forced uniqueness)
- Runs automatically after every ingest when rules are configured
- `DEFAULT_RECONCILIATION_RULES` ships as a conservative starter set (current_city, current_employer, primary_diet, etc.)

**Read-time decay**
- `getActiveBeliefs/Preferences/Identities` compute `effective_strength = strength * 2^(-age/half_life)` at read time
- Returned facts include `effective_strength` and `age_days`; stored facts untouched
- `decayConfig.minEffectiveStrength` defaults to 0 → back-compat preserved; raise to drop stale facts

**Bootstrap**
- `scripts/bootstrap-alex.mjs` rewritten to drive everything through the public `Marble` class: `init → ingestConversations → ingestEpisodes → learn → investigate → save`
- L1.5 / L2 / L3 now actually fire on bootstrap (previously skipped)

**Misc**
- `maxChunks` cap now warns instead of silently truncating (feedback #15)

## Test plan

- [x] New `test/temporal-truth.test.js` — 8 tests covering episodes, source timestamps, reconciliation, decay threshold, historical queries
- [x] Full suite: 29/29 passing (`npm test`)
- [x] Bootstrap script parses (`node -c scripts/bootstrap-alex.mjs`)

## Back-compat

- Existing `addBelief/addPreference/addIdentity(topic, claim, strength)` positional calls still work; the options arg is optional
- `getActiveX()` returns the same shape plus computed fields; threshold 0 means no filtering unless consumers opt in
- Older KG JSON files auto-migrate on load (add `episodes: []`)

Follow-ups tracked separately: DX cleanup (broken test imports, `learn()` change counts), entity resolution, CLI + diagnose, shared reasoning bundle, multi-subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)