### PR TITLE
fix: honor user-supplied llm in seedClones, L1.5, and L2

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -428,6 +428,15 @@ export class Marble {
     const cloneStatusBefore = new Map();
     for (const c of this.kg.user.clones || []) cloneStatusBefore.set(c.id, c.status);
 
+    // Resolve a single LLM client for this learn() run. If the user passed
+    // `opts.llm` (a raw `(prompt) => string` function) to the Marble
+    // constructor, wrap it so downstream code that expects the Anthropic
+    // `messages.create()` shape (seedClones, L1.5 insight-swarm, L2
+    // inference) uses it instead of silently falling back to env-based
+    // provider discovery.
+    const { createLLMClient, wrapUserLLM } = await import('./llm-provider.js');
+    const llmClient = this.llm ? wrapUserLLM(this.llm) : createLLMClient();
+
     // Seed clones if none exist. Persist the returned array — historically
     // the result was discarded, so seeded clones never reached `user.clones`
     // and every downstream `clones === 0` check looked identical to a cold
@@ -436,9 +445,7 @@ export class Marble {
     const existingClones = this.kg.getActiveClones();
     if (existingClones.length === 0 && typeof this.kg.seedClones === 'function') {
       try {
-        const { createLLMClient } = await import('./llm-provider.js');
-        const client = createLLMClient();
-        const seeded = await this.kg.seedClones(client, client.defaultModel('fast'));
+        const seeded = await this.kg.seedClones(llmClient, llmClient.defaultModel('fast'));
         if (Array.isArray(seeded) && seeded.length > 0) {
           for (const clone of seeded) this.kg.saveClone(clone);
           stages.seedClones = 'ok';
@@ -466,7 +473,7 @@ export class Marble {
     let insights = [];
     try {
       const { runInsightSwarm } = await import('./insight-swarm.js');
-      insights = await runInsightSwarm(this.kg);
+      insights = await runInsightSwarm(this.kg, { llmClient });
       recordLayerContribution(bundle, 'insightSwarm', { insights });
       stages.insightSwarm = 'ok';
     } catch (err) {
@@ -478,7 +485,7 @@ export class Marble {
     let candidates = [];
     try {
       const { InferenceEngine } = await import('./inference-engine.js');
-      const inference = new InferenceEngine(this.kg);
+      const inference = new InferenceEngine(this.kg, { llmClient });
       candidates = await inference.run();
       recordLayerContribution(bundle, 'inferenceEngine', { hypotheses: candidates });
       stages.inference = 'ok';

--- a/core/inference-engine.js
+++ b/core/inference-engine.js
@@ -23,6 +23,7 @@ export class InferenceEngine extends EventEmitter {
     this.processedFacts = new Set();
     this.confidenceThreshold = opts.confidenceThreshold || 0.65;
     this.minSupportingFacts = opts.minSupportingFacts || 2;
+    this.llmClient = opts.llmClient || null;
     this.isRunning = false;
     this.lastRunAt = null;
   }
@@ -40,8 +41,11 @@ export class InferenceEngine extends EventEmitter {
       const summary = this.kg.getMemoryNodesSummary();
       const candidates = [];
 
-      // Seed from L1.5 insight-swarm output (cross-dimensional analysis)
-      const l1_5_seeds = await getL2Seeds(this.kg);
+      // Seed from L1.5 insight-swarm output (cross-dimensional analysis).
+      // Forward `llmClient` so L1.5 runs against the user-supplied LLM when
+      // Marble was constructed with `{ llm }`; otherwise insight-swarm falls
+      // back to env-based provider discovery.
+      const l1_5_seeds = await getL2Seeds(this.kg, this.llmClient ? { llmClient: this.llmClient } : {});
       candidates.push(...l1_5_seeds.map(seed => ({
         question: seed.insight,
         supporting_L1_facts: seed.supporting_facts || [],

--- a/core/llm-provider.js
+++ b/core/llm-provider.js
@@ -120,6 +120,43 @@ export function createLLMClient(opts = {}) {
 }
 
 /**
+ * Wrap a user-supplied `async (prompt: string) => string` function into an
+ * Anthropic-shape client that exposes `messages.create({ model, max_tokens, messages })`.
+ *
+ * This lets callers that expect the internal client shape (kg.seedClones,
+ * runInsightSwarm, InferenceEngine, etc.) use a raw user LLM function
+ * without each call site needing its own adapter.
+ *
+ * Multi-message arrays are flattened into a single text prompt; callers that
+ * need structured turn-taking with a non-Anthropic provider should build
+ * their own client rather than pass a raw function.
+ *
+ * @param {Function} userFn - async (prompt: string) => string
+ * @param {Object} [opts]
+ * @param {string} [opts.provider='custom'] - Provider label for diagnostics
+ * @param {string} [opts.model='user-supplied'] - Model label returned by defaultModel()
+ * @returns {{ messages: { create: Function }, provider: string, defaultModel: Function }}
+ */
+export function wrapUserLLM(userFn, { provider = 'custom', model = 'user-supplied' } = {}) {
+  if (typeof userFn !== 'function') {
+    throw new TypeError('[llm-provider] wrapUserLLM requires an async (prompt) => string function');
+  }
+  return {
+    provider,
+    defaultModel: () => model,
+    messages: {
+      async create({ messages } = {}) {
+        const prompt = (messages || [])
+          .map(m => m.role === 'user' ? m.content : `[${m.role}]: ${m.content}`)
+          .join('\n\n');
+        const text = await userFn(prompt);
+        return { content: [{ type: 'text', text: String(text ?? '') }] };
+      },
+    },
+  };
+}
+
+/**
  * Get the default model name for a given tier and provider.
  * @param {'heavy'|'fast'} tier
  * @param {string} [provider]

--- a/core/swarm.js
+++ b/core/swarm.js
@@ -873,9 +873,11 @@ const _URL_PATTERN = /https?:\/\/([^\s\/]+)/gi;
  *
  * @param {string} contentSample - Title + summary + url, etc.
  * @param {boolean} [useLLM=false] - Force LLM if heuristics are inconclusive
+ * @param {Object}  [opts]
+ * @param {Object}  [opts.llmClient] - Pre-built Anthropic-shape client (overrides env discovery)
  * @returns {Promise<{domain: string, availableSignals: string[], contextHint: string}>}
  */
-export async function detectDomain(contentSample, useLLM = false) {
+export async function detectDomain(contentSample, useLLM = false, opts = {}) {
   if (!contentSample || typeof contentSample !== 'string') {
     return { domain: 'unknown', availableSignals: [], contextHint: 'No content to analyze' };
   }
@@ -906,7 +908,7 @@ export async function detectDomain(contentSample, useLLM = false) {
 
   if (!detectedDomain && (useLLM || signals.length === 0)) {
     try {
-      const client = createLLMClient();
+      const client = opts.llmClient || createLLMClient();
       const response = await client.messages.create({
         model: process.env.MARBLE_LLM_MODEL || defaultModel('fast'),
         max_tokens: 150,

--- a/test/custom-llm-propagation.test.js
+++ b/test/custom-llm-propagation.test.js
@@ -1,0 +1,199 @@
+/**
+ * custom-llm-propagation.test.js
+ *
+ * Regression tests proving that a user-supplied `llm` function passed to
+ * `new Marble({ llm })` is honored throughout the learn() pipeline —
+ * specifically at seedClones, L1.5 (insight swarm), and L2 (inference engine).
+ *
+ * Before the fix, each of these stages called `createLLMClient()` directly,
+ * silently ignoring the user's function and falling back to env-based
+ * provider discovery (defaulting to Anthropic).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Marble } from '../core/index.js';
+import { wrapUserLLM } from '../core/llm-provider.js';
+import { runInsightSwarm } from '../core/insight-swarm.js';
+import { InferenceEngine } from '../core/inference-engine.js';
+import { KnowledgeGraph } from '../core/kg.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function tmpKgPath() {
+  const dir = mkdtempSync(join(tmpdir(), 'marble-custom-llm-'));
+  return { path: join(dir, 'kg.json'), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe('wrapUserLLM adapter', () => {
+  it('wraps a (prompt) => string function into an Anthropic-shape client', async () => {
+    const calls = [];
+    const fn = async (prompt) => {
+      calls.push(prompt);
+      return 'ok-response';
+    };
+    const client = wrapUserLLM(fn);
+
+    assert.equal(client.provider, 'custom');
+    assert.equal(typeof client.defaultModel, 'function');
+    assert.equal(typeof client.messages.create, 'function');
+
+    const resp = await client.messages.create({
+      model: 'x',
+      max_tokens: 100,
+      messages: [{ role: 'user', content: 'hello world' }],
+    });
+
+    assert.equal(calls.length, 1, 'user function should be called exactly once');
+    assert.equal(calls[0], 'hello world', 'user function should receive the user-turn content');
+    assert.deepEqual(resp, { content: [{ type: 'text', text: 'ok-response' }] });
+  });
+
+  it('rejects non-function inputs', () => {
+    assert.throws(() => wrapUserLLM(null), TypeError);
+    assert.throws(() => wrapUserLLM({}), TypeError);
+    assert.throws(() => wrapUserLLM('not a fn'), TypeError);
+  });
+
+  it('flattens multi-message conversations into a single prompt', async () => {
+    let received = null;
+    const client = wrapUserLLM(async (p) => { received = p; return ''; });
+    await client.messages.create({
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'what time is it' },
+      ],
+    });
+    assert.match(received, /be brief/);
+    assert.match(received, /what time is it/);
+  });
+});
+
+describe('learn() pipeline honors user-supplied llm', () => {
+  it('calls the user llm at L1.5 and L2 instead of createLLMClient()', async () => {
+    const { path, cleanup } = tmpKgPath();
+    try {
+      // Track every prompt the user fn receives. We intentionally return
+      // non-JSON so insight-swarm parsing fails — but the call itself
+      // proves our llm was threaded through rather than a real SDK client.
+      const prompts = [];
+      const userLLM = async (prompt) => {
+        prompts.push(prompt);
+        return 'no';
+      };
+
+      const marble = new Marble({ storage: path, llm: userLLM, silent: true });
+      await marble.init();
+
+      // Pre-seed a clone so learn() skips the seedClones stage
+      // (we test seedClones-routing separately below).
+      marble.kg.saveClone({
+        id: 'test_clone_1', gap: 'x', hypothesis: 'h',
+        kgOverrides: { beliefs: [], preferences: [], identities: [] },
+        confidence: 0.6, evaluations: [], spawnedFrom: null, generation: 0,
+        createdAt: Date.now(), lastScoredAt: Date.now(), status: 'active',
+      });
+      // Add some beliefs/prefs so L1.5 has material to probe
+      marble.kg.user.beliefs = [{ topic: 'running', claim: 'enjoys long runs', confidence: 0.7 }];
+      marble.kg.user.preferences = [{ category: 'pace', value: 'slow', strength: 0.7 }];
+
+      const priorCount = prompts.length;
+      await marble.learn();
+
+      assert.ok(
+        prompts.length > priorCount,
+        `user-supplied llm should be called during learn(); got ${prompts.length} total calls`,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('routes seedClones through the user llm when no clones exist yet', async () => {
+    const { path, cleanup } = tmpKgPath();
+    try {
+      let seedClonesPrompt = null;
+      const userLLM = async (prompt) => {
+        // Mark seedClones prompts by the archetype keyword it uses
+        if (/archetype/i.test(prompt)) seedClonesPrompt = prompt;
+        return JSON.stringify([
+          { gap: 'x', hypothesis: 'h',
+            kgOverrides: { beliefs: [], preferences: [], identities: [] },
+            confidence: 0.5 },
+        ]);
+      };
+
+      const marble = new Marble({ storage: path, llm: userLLM, silent: true });
+      await marble.init();
+      marble.kg.user.interests = [{ topic: 'running', weight: 0.8 }];
+      marble.kg.user.preferences = [{ category: 'pace', value: 'slow', strength: 0.7 }];
+
+      await marble.learn();
+
+      assert.ok(
+        seedClonesPrompt && seedClonesPrompt.length > 0,
+        'seedClones should invoke the user llm (expected an archetype-building prompt)',
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('runInsightSwarm honors opts.llmClient', () => {
+  it('calls opts.llmClient.messages.create instead of env-based default', async () => {
+    const { path, cleanup } = tmpKgPath();
+    try {
+      const kg = new KnowledgeGraph(path);
+      await kg.load();
+      kg.user.beliefs = [{ topic: 'coffee', claim: 'likes dark roast', confidence: 0.8 }];
+
+      let called = false;
+      const stubClient = {
+        provider: 'stub',
+        defaultModel: () => 'stub-model',
+        messages: {
+          create: async () => {
+            called = true;
+            return { content: [{ type: 'text', text: '[]' }] };
+          },
+        },
+      };
+
+      await runInsightSwarm(kg, { llmClient: stubClient });
+      assert.ok(called, 'runInsightSwarm should invoke the supplied llmClient');
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('InferenceEngine forwards llmClient to L1.5', () => {
+  it('passes constructor opts.llmClient down to getL2Seeds', async () => {
+    const { path, cleanup } = tmpKgPath();
+    try {
+      const kg = new KnowledgeGraph(path);
+      await kg.load();
+      kg.user.beliefs = [{ topic: 'coffee', claim: 'likes dark roast', confidence: 0.8 }];
+
+      let called = false;
+      const stubClient = {
+        provider: 'stub',
+        defaultModel: () => 'stub-model',
+        messages: {
+          create: async () => {
+            called = true;
+            return { content: [{ type: 'text', text: '[]' }] };
+          },
+        },
+      };
+
+      const inference = new InferenceEngine(kg, { llmClient: stubClient });
+      await inference.run();
+      assert.ok(called, 'InferenceEngine should forward llmClient through to getL2Seeds');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `Marble` accepts `{ llm: (prompt) => string }` but its `learn()` pipeline was silently dropping that function at **seedClones**, **L1.5 (insight-swarm)**, and **L2 (inference-engine)** — every one of those stages called `createLLMClient()` directly, falling back to env-based provider discovery (default Anthropic).
- Adds a `wrapUserLLM()` adapter that converts a raw `(prompt) => string` into the Anthropic-shape `messages.create()` client downstream code expects, and threads a single resolved `llmClient` through the three bypass points.
- Also extends `detectDomain(sample, useLLM, opts)` with an optional `opts.llmClient` (backwards-compatible — existing callers pass only two args).

## What was broken

Bypass points that called `createLLMClient()` unconditionally and ignored `this.llm`:

1. `core/index.js:438-441` — seedClones
2. `core/index.js:469` — `runInsightSwarm(this.kg)` (**L1.5**)
3. `core/index.js:481-482` — `new InferenceEngine(this.kg)` → `getL2Seeds(kg)` (**L2**)
4. `core/swarm.js:909` — `detectDomain` LLM fallback

Shape mismatch: `opts.llm` is `async (prompt) => string`, but seedClones / insight-swarm expect `.messages.create({ model, max_tokens, messages })`. The new `wrapUserLLM()` closes this gap.

## Test plan

- [x] New `test/custom-llm-propagation.test.js` — 7 tests covering:
  - `wrapUserLLM` adapter shape + error handling + multi-message flattening
  - `learn()` routes through user's llm at L1.5 and L2
  - `learn()` routes through user's llm at seedClones
  - `runInsightSwarm({ llmClient })` calls the supplied client
  - `InferenceEngine({ llmClient })` forwards to `getL2Seeds`
- [x] Full suite: 77 tests pass, 0 fail