### PR TITLE
fix: persist L1.5 insights and reuse swarm seeds in L2

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -474,6 +474,8 @@ export class Marble {
     try {
       const { runInsightSwarm } = await import('./insight-swarm.js');
       insights = await runInsightSwarm(this.kg, { llmClient });
+      if (!Array.isArray(this.kg.user.insights)) this.kg.user.insights = [];
+      this.kg.user.insights = insights;
       recordLayerContribution(bundle, 'insightSwarm', { insights });
       stages.insightSwarm = 'ok';
     } catch (err) {
@@ -481,11 +483,13 @@ export class Marble {
       pushFailure('insightSwarm', err);
     }
 
-    // L2: Inference Engine — generate candidates from L1 facts + L1.5 insights
+    // L2: Inference Engine — generate candidates from L1 facts + L1.5 insights.
+    // Pass the insights we just computed as pre-built seeds so InferenceEngine
+    // doesn't re-invoke the LLM swarm (expensive and a second failure surface).
     let candidates = [];
     try {
       const { InferenceEngine } = await import('./inference-engine.js');
-      const inference = new InferenceEngine(this.kg, { llmClient });
+      const inference = new InferenceEngine(this.kg, { llmClient, seeds: insights });
       candidates = await inference.run();
       recordLayerContribution(bundle, 'inferenceEngine', { hypotheses: candidates });
       stages.inference = 'ok';

--- a/core/inference-engine.js
+++ b/core/inference-engine.js
@@ -24,6 +24,10 @@ export class InferenceEngine extends EventEmitter {
     this.confidenceThreshold = opts.confidenceThreshold || 0.65;
     this.minSupportingFacts = opts.minSupportingFacts || 2;
     this.llmClient = opts.llmClient || null;
+    // Pre-built L1.5 insights from the caller. When provided we skip the
+    // LLM swarm — `learn()` already ran it and a second call would both
+    // double the LLM spend and introduce a second failure surface.
+    this.seeds = Array.isArray(opts.seeds) ? opts.seeds : null;
     this.isRunning = false;
     this.lastRunAt = null;
   }
@@ -42,15 +46,17 @@ export class InferenceEngine extends EventEmitter {
       const candidates = [];
 
       // Seed from L1.5 insight-swarm output (cross-dimensional analysis).
-      // Forward `llmClient` so L1.5 runs against the user-supplied LLM when
-      // Marble was constructed with `{ llm }`; otherwise insight-swarm falls
-      // back to env-based provider discovery.
-      const l1_5_seeds = await getL2Seeds(this.kg, this.llmClient ? { llmClient: this.llmClient } : {});
+      // Prefer caller-supplied seeds (from `learn()`) to avoid re-running the
+      // swarm. Fall back to `getL2Seeds` for callers that instantiate the
+      // engine standalone.
+      const l1_5_seeds = this.seeds
+        ? this.seeds.filter(i => i.l2_seed)
+        : await getL2Seeds(this.kg, this.llmClient ? { llmClient: this.llmClient } : {});
       candidates.push(...l1_5_seeds.map(seed => ({
         question: seed.insight,
         supporting_L1_facts: seed.supporting_facts || [],
         confidence: seed.confidence,
-        second_order_effects: seed.implications || [],
+        second_order_effects: seed.derived_predictions || [],
         source: 'l1.5-insight-swarm',
         generated_at: new Date().toISOString()
       })));

--- a/core/kg.js
+++ b/core/kg.js
@@ -1652,7 +1652,8 @@ export class KnowledgeGraph {
       confidence: {},     // Confidence by domain: { domain: confidence_score (0-1) }
       clones: [],         // UserClone hypothesis array
       episodes: [],       // Source records: { id, source, source_date, ingested_at, content_hash, content_summary?, metadata? }
-      entities: []        // Canonical entities: { id, canonical, aliases: [], embedding? } — collapses "BSB" ↔ "British School Barcelona"
+      entities: [],       // Canonical entities: { id, canonical, aliases: [], embedding? } — collapses "BSB" ↔ "British School Barcelona"
+      insights: []        // L1.5 insight-swarm output: { insight, question, confidence, supporting_facts, lens, agent, source_layer, l2_seed, ... }
     };
   }
 


### PR DESCRIPTION
## Summary

- **Bug 1:** `learn()` generated insights via `runInsightSwarm()` but never wrote them to `kg.user.insights` — the slot that `insight-engine.js` and `hypothesis-tester.js` read from. Adds the slot to `#defaultUser()` and persists the swarm output after it runs.
- **Bug 2 (root cause of "InsightSwarm ran fine but InferenceEngine still fails"):** `InferenceEngine` called `getL2Seeds()`, which re-ran the full LLM swarm a second time. `learn()` had already run it 10 lines earlier. The duplicate call doubled LLM spend and added a second failure surface — if it tripped on a transient provider error, L2 threw even though L1.5 succeeded. Engine now accepts pre-built `seeds` via opts; `learn()` passes the insights it just computed. Standalone callers still fall through to `getL2Seeds`.
- **Bonus fix:** `inference-engine.js` line 53 read `seed.implications`, but swarm insights have no such field — the intended source is `derived_predictions`. `second_order_effects` was always `[]` for L1.5-seeded candidates before this.

## Files changed

- [`core/kg.js`](../blob/claude/persist-insights-and-reuse-swarm-seeds/core/kg.js#L1655) — added `insights: []` to `#defaultUser()`
- [`core/index.js`](../blob/claude/persist-insights-and-reuse-swarm-seeds/core/index.js#L477) — `learn()` persists insights and forwards them as seeds to `InferenceEngine`
- [`core/inference-engine.js`](../blob/claude/persist-insights-and-reuse-swarm-seeds/core/inference-engine.js#L30) — constructor accepts `opts.seeds`; `run()` uses them when present; fixes `implications` → `derived_predictions`

## Test plan

- [x] `npm test` — 77 passed, 0 failed
- [x] Targeted: `reasoning-bundle.test.js`, `learn-reliability.test.js`, `custom-llm-propagation.test.js` all pass
- [x] Standalone `new InferenceEngine(kg)` callers still work via the `getL2Seeds` fallback (no breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)