### PR TITLE
feat: L2 trait synthesis \u2014 derivation, replication, contradiction, fusion

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -598,6 +598,31 @@ export class Marble {
   }
 
   /**
+   * Run L2 trait synthesis — derive psychological/behavioral traits from
+   * individual facts, check whether those traits replicate across domains
+   * or get contradicted elsewhere in the KG, and run a small K-way fusion
+   * pass for emergent gestalt patterns.
+   *
+   * Output syntheses are persisted to `kg.user.syntheses` and returned.
+   * Designed to run AFTER `learn()` + `investigate()` so the full multi-layer
+   * KG is available as raw material.
+   *
+   * @param {Object} [opts] - see runTraitSynthesis in trait-synthesis.js
+   * @returns {Promise<Object[]>} the persisted Synthesis records
+   */
+  async synthesize(opts = {}) {
+    if (!this.ready) await this.init();
+
+    const llmClient = opts.llmClient || this.llm || undefined;
+    const { InferenceEngine } = await import('./inference-engine.js');
+    const engine = new InferenceEngine(this.kg, { llmClient });
+
+    const syntheses = await engine.runTraitSynthesis({ ...opts, llmClient });
+    await this.kg.save();
+    return syntheses;
+  }
+
+  /**
    * Run deep investigation of the user profile.
    * Assembles a per-user committee, generates questions, answers from data sources,
    * cross-references findings, debates.

--- a/core/inference-engine.js
+++ b/core/inference-engine.js
@@ -92,6 +92,33 @@ export class InferenceEngine extends EventEmitter {
   }
 
   /**
+   * Run L2 trait synthesis — third inference mode alongside L1.5 passthrough
+   * and pairwise L1. Derives psychological/behavioral traits from individual
+   * facts, checks replication across domains, surfaces contradictions, and
+   * runs a small K-way fusion pass on top. Persists results via
+   * `kg.addSynthesis()`.
+   *
+   * The heavy logic lives in `trait-synthesis.js` — this method is a thin
+   * wrapper that threads `llmClient` through and writes the results back
+   * into the KG.
+   *
+   * @param {Object} [opts] — see `runTraitSynthesis` in trait-synthesis.js
+   * @returns {Promise<Object[]>} persisted syntheses (with ids)
+   */
+  async runTraitSynthesis(opts = {}) {
+    const { runTraitSynthesis } = await import('./trait-synthesis.js');
+    const syntheses = await runTraitSynthesis(this.kg, {
+      ...opts,
+      llmClient: opts.llmClient || this.llmClient || undefined,
+    });
+    const persisted = [];
+    for (const s of syntheses) {
+      persisted.push(this.kg.addSynthesis(s));
+    }
+    return persisted;
+  }
+
+  /**
    * Infer second-order questions from pairs of beliefs
    * @private
    */

--- a/core/kg.js
+++ b/core/kg.js
@@ -1653,7 +1653,8 @@ export class KnowledgeGraph {
       clones: [],         // UserClone hypothesis array
       episodes: [],       // Source records: { id, source, source_date, ingested_at, content_hash, content_summary?, metadata? }
       entities: [],       // Canonical entities: { id, canonical, aliases: [], embedding? } — collapses "BSB" ↔ "British School Barcelona"
-      insights: []        // L1.5 insight-swarm output: { insight, question, confidence, supporting_facts, lens, agent, source_layer, l2_seed, ... }
+      insights: [],       // L1.5 insight-swarm output: { insight, question, confidence, supporting_facts, lens, agent, source_layer, l2_seed, ... }
+      syntheses: []       // L2 trait-synthesis output: { id, label, origin, trait, mechanics, reinforcing_nodes, contradicting_nodes, domains_bridged, confidence, confidence_components, affinities, aversions, predictions, surprising, ... }
     };
   }
 
@@ -1897,5 +1898,85 @@ Return ONLY the JSON object.`,
       bred += 1;
     }
     return { bred, failures };
+  }
+
+  // ── Syntheses (L2 trait synthesis) ──────────────────────────────────────
+
+  /**
+   * Persist a synthesis record. Assigns a stable id and generated_at if the
+   * caller didn't provide them. Syntheses with matching (origin, dimension,
+   * value) are upserted in place so re-runs of trait synthesis don't
+   * duplicate the same pattern — the newer record wins when its confidence
+   * is higher, otherwise the older one is kept.
+   *
+   * @param {Object} synthesis
+   * @returns {Object} the stored record
+   */
+  addSynthesis(synthesis) {
+    if (!this.user.syntheses) this.user.syntheses = [];
+    const record = { ...synthesis };
+    if (!record.id) {
+      record.id = `synth_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+    if (!record.generated_at) record.generated_at = new Date().toISOString();
+
+    const key = `${record.origin}|${record.trait?.dimension}|${record.trait?.value}`;
+    const idx = this.user.syntheses.findIndex(s =>
+      `${s.origin}|${s.trait?.dimension}|${s.trait?.value}` === key
+    );
+    if (idx !== -1) {
+      const existing = this.user.syntheses[idx];
+      if ((record.confidence ?? 0) >= (existing.confidence ?? 0)) {
+        // Preserve the original id so callers' references stay valid.
+        record.id = existing.id;
+        this.user.syntheses[idx] = record;
+      }
+      return this.user.syntheses[idx];
+    }
+    this.user.syntheses.push(record);
+    return record;
+  }
+
+  /**
+   * Query syntheses with optional filters.
+   *
+   * @param {Object} [opts]
+   * @param {number}   [opts.minConfidence]       - Drop below this.
+   * @param {string}   [opts.origin]              - "single_node" | "trait_replication" | "contradiction" | "emergent_fusion"
+   * @param {boolean}  [opts.surprising]          - Only return records flagged surprising.
+   * @param {Object}   [opts.trait]               - Match trait.dimension / trait.value (both optional).
+   * @param {string[]} [opts.domainsIncludes]     - Match syntheses whose domains_bridged includes ALL of these.
+   * @returns {Object[]}
+   */
+  getSyntheses(opts = {}) {
+    const all = this.user.syntheses || [];
+    return all.filter(s => {
+      if (opts.minConfidence != null && (s.confidence ?? 0) < opts.minConfidence) return false;
+      if (opts.origin && s.origin !== opts.origin) return false;
+      if (opts.surprising === true && !s.surprising) return false;
+      if (opts.trait?.dimension && s.trait?.dimension !== opts.trait.dimension) return false;
+      if (opts.trait?.value && s.trait?.value !== opts.trait.value) return false;
+      if (Array.isArray(opts.domainsIncludes) && opts.domainsIncludes.length > 0) {
+        const have = new Set(s.domains_bridged || []);
+        if (!opts.domainsIncludes.every(d => have.has(d))) return false;
+      }
+      return true;
+    });
+  }
+
+  /**
+   * Return syntheses whose provenance mentions the given node ref
+   * (reinforcing or contradicting side). Useful for "what patterns does
+   * this fact support or undermine?" queries.
+   *
+   * @param {string} nodeRef - e.g. "belief:running", "preference:pace"
+   * @returns {Object[]}
+   */
+  getSynthesesForNode(nodeRef) {
+    const all = this.user.syntheses || [];
+    return all.filter(s =>
+      (s.reinforcing_nodes || []).includes(nodeRef) ||
+      (s.contradicting_nodes || []).includes(nodeRef)
+    );
   }
 }

--- a/core/trait-synthesis.js
+++ b/core/trait-synthesis.js
@@ -1,0 +1,606 @@
+/**
+ * Marble L2 Trait Synthesis
+ *
+ * Derives psychological/behavioral traits from individual facts, then checks
+ * whether each trait replicates across domains (confidence up) or gets
+ * contradicted elsewhere in the KG (surface as first-class inconsistency).
+ * A smaller K-way fusion pass covers genuinely gestalt patterns that no
+ * single-node extraction would produce.
+ *
+ * Four phases:
+ *   1. Per-node trait extraction (LLM, batched by chunks of nodes)
+ *   2. Replication grouping (deterministic, in-process)
+ *   3. Contradiction detection (deterministic — same dimension, divergent
+ *      values from distinct node sets)
+ *   4. Emergent K-way fusion (LLM, small number of samples)
+ *
+ * Output: Synthesis[] — each with structured trait, evidence, confidence
+ * components, affinities, aversions, predictions, provenance.
+ *
+ * Requires: LLM_PROVIDER + API key in env, OR opts.llmClient.
+ */
+
+import { createLLMClient } from './llm-provider.js';
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+const DEFAULTS = Object.freeze({
+  perNodeExtraction:   true,
+  extractionChunkSize: 10,
+  fusionSamples:       5,
+  k:                   10,
+  contradictionScan:   true,
+  domainSpread:        true,
+  strengthRange:       [0.4, 0.9],
+  alpha:               0.15,
+  beta:                1.3,
+  gamma:               0.2,
+  requireSurprising:   false,
+  minConfidence:       0.4,
+  schemaStrict:        true,
+});
+
+// ── Parse Failure Counter (matches insight-swarm.js pattern) ───────────────
+
+export const parseFailureCounter = {
+  counts: {},
+  increment(phase) { this.counts[phase] = (this.counts[phase] || 0) + 1; },
+  reset()  { this.counts = {}; },
+  total()  { return Object.values(this.counts).reduce((s, v) => s + v, 0); },
+  report() { return { total: this.total(), byPhase: { ...this.counts } }; },
+};
+
+// Tolerant JSON parser — mirrors insight-swarm.js
+function _parseJSON(text, phaseName = 'unknown') {
+  const s = String(text).trim();
+  try { return JSON.parse(s); } catch {}
+  const fence = s.match(/```json?\s*\n?([\s\S]*?)\n?\s*```/);
+  if (fence) { try { return JSON.parse(fence[1].trim()); } catch {} }
+  const obj = s.indexOf('{'), objE = s.lastIndexOf('}');
+  if (obj !== -1 && objE > obj) { try { return JSON.parse(s.slice(obj, objE + 1)); } catch {} }
+  const arr = s.indexOf('['), arrE = s.lastIndexOf(']');
+  if (arr !== -1 && arrE > arr) { try { return JSON.parse(s.slice(arr, arrE + 1)); } catch {} }
+  parseFailureCounter.increment(phaseName);
+  return null;
+}
+
+// ── Node Normalization ─────────────────────────────────────────────────────
+
+/**
+ * Collect all L1 nodes from the KG and normalize them to a common shape.
+ * Each node gets a stable `ref` (e.g. "belief:running", "preference:pace",
+ * "identity:founder") used as the provenance anchor in syntheses.
+ */
+function collectNodes(kg, strengthRange) {
+  const [lo, hi] = strengthRange;
+  const user = kg.user || kg.getUser?.() || {};
+  const nodes = [];
+
+  for (const b of user.beliefs || []) {
+    if (b.valid_to) continue;
+    const s = b.strength ?? 0.7;
+    if (s < lo || s > hi) continue;
+    nodes.push({
+      ref: `belief:${b.topic}`,
+      type: 'belief',
+      strength: s,
+      text: `Belief — ${b.topic}: ${b.claim}`,
+    });
+  }
+  for (const p of user.preferences || []) {
+    if (p.valid_to) continue;
+    const s = p.strength ?? 0.7;
+    if (s < lo || s > hi) continue;
+    const desc = p.description || p.value || '';
+    const type = p.type || p.category || 'unknown';
+    nodes.push({
+      ref: `preference:${type}`,
+      type: 'preference',
+      strength: s,
+      text: `Preference — ${type}: ${desc}`,
+    });
+  }
+  for (const i of user.identities || []) {
+    if (i.valid_to) continue;
+    const s = i.salience ?? 0.8;
+    if (s < lo || s > hi) continue;
+    nodes.push({
+      ref: `identity:${i.role}`,
+      type: 'identity',
+      strength: s,
+      text: `Identity — ${i.role}${i.context ? ` (${i.context})` : ''}`,
+    });
+  }
+  return nodes;
+}
+
+// ── Phase 1: Per-node Trait Extraction ─────────────────────────────────────
+
+async function extractTraits(nodes, llmClient, model, opts) {
+  const chunkSize = opts.extractionChunkSize;
+  const out = [];
+
+  for (let i = 0; i < nodes.length; i += chunkSize) {
+    const chunk = nodes.slice(i, i + chunkSize);
+    const prompt = buildExtractionPrompt(chunk);
+
+    try {
+      const res = await llmClient.messages.create({
+        model,
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: prompt }],
+      });
+      const text = res.content?.[0]?.text || res.content || '';
+      const parsed = _parseJSON(text, 'extraction');
+      if (!Array.isArray(parsed)) continue;
+
+      for (const entry of parsed) {
+        if (!entry || typeof entry.node_ref !== 'string') continue;
+        if (!Array.isArray(entry.traits)) continue;
+        const domain = typeof entry.domain === 'string' ? entry.domain.toLowerCase().trim() : 'unknown';
+        for (const t of entry.traits) {
+          if (!t || !t.dimension || !t.value) continue;
+          out.push({
+            node_ref:    entry.node_ref,
+            domain,
+            dimension:   String(t.dimension).toLowerCase().trim(),
+            value:       String(t.value).toLowerCase().trim(),
+            weight:      clamp(Number(t.weight ?? 0.6), 0, 1),
+            base_conf:   clamp(Number(t.confidence ?? 0.6), 0, 1),
+            evidence_q:  typeof t.evidence_quote === 'string' ? t.evidence_quote : '',
+          });
+        }
+      }
+    } catch (err) {
+      console.error('[TraitSynthesis] extraction chunk failed:', err.message);
+    }
+  }
+
+  return out;
+}
+
+function buildExtractionPrompt(chunk) {
+  const lines = chunk.map(n => `  - [${n.ref}] ${n.text} (strength=${n.strength.toFixed(2)})`);
+  return `You are analyzing individual facts about a user to extract psychological/behavioral traits that each fact implies on its own.
+
+FACTS:
+${lines.join('\n')}
+
+For EACH fact, extract 1-3 traits it implies. A trait is a compact predicate a downstream system can match against content.
+
+Rules:
+- Each trait must have: dimension (e.g. "time_orientation"), value (e.g. "compound"), weight (0-1, how strong this implication is from THIS fact alone), confidence (0-1, how sure).
+- Prefer short snake_case values. Use enum-like vocabularies where natural (e.g. time_orientation: compound|peak_driven|short_horizon).
+- Include a short evidence_quote copying the exact fragment of the fact that supports the trait.
+- Also classify each fact into a life domain: health, work, family, spirituality, hobbies, finance, relationships, politics, intellectual, or other.
+- Do NOT invent traits that aren't supported — isolated facts carry only moderate weight. If no meaningful trait, return traits: [].
+
+Respond with JSON array only. Each element has node_ref, domain, traits.
+
+[
+  {
+    "node_ref": "belief:running",
+    "domain": "health",
+    "traits": [
+      { "dimension": "time_orientation",   "value": "compound", "weight": 0.7, "confidence": 0.65, "evidence_quote": "enjoys long runs" },
+      { "dimension": "effort_profile",     "value": "sustained_low_intensity", "weight": 0.8, "confidence": 0.7, "evidence_quote": "long runs" }
+    ]
+  }
+]`;
+}
+
+// ── Phase 2: Replication Grouping ──────────────────────────────────────────
+
+/**
+ * Group candidate traits by (dimension, value). For each group, compute
+ * reinforcing_nodes, domains_bridged, and a replication-adjusted confidence.
+ */
+function groupByReplication(candidates, opts) {
+  const byKey = new Map();
+  for (const c of candidates) {
+    const key = `${c.dimension}|${c.value}`;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(c);
+  }
+
+  const groups = [];
+  for (const [key, members] of byKey.entries()) {
+    const reinforcingRefs = [...new Set(members.map(m => m.node_ref))];
+    const domains = [...new Set(members.map(m => m.domain).filter(Boolean))];
+    const base = avg(members.map(m => m.base_conf));
+    const weight = avg(members.map(m => m.weight));
+    const crossDomain = domains.length > 1;
+
+    const replicationBonus = Math.min(
+      0.3,
+      opts.alpha * Math.log(1 + reinforcingRefs.length)
+    ) * (crossDomain ? opts.beta : 1.0);
+
+    groups.push({
+      key,
+      dimension: members[0].dimension,
+      value:     members[0].value,
+      weight,
+      reinforcing_refs: reinforcingRefs,
+      reinforcing_members: members,
+      domains_bridged: domains,
+      cross_domain: crossDomain,
+      base_conf: base,
+      replication_bonus: replicationBonus,
+      isolated: reinforcingRefs.length === 1,
+    });
+  }
+  return groups;
+}
+
+// ── Phase 3: Contradiction Detection ───────────────────────────────────────
+
+/**
+ * For each dimension that has multiple distinct values (i.e. at least two
+ * non-overlapping trait groups), emit a contradiction record. Deterministic:
+ * no LLM call — we expose the raw divergence and let downstream tools (or
+ * the user) decide if it's genuine tension or just complexity. Contradictions
+ * are only recorded when the two sides come from DIFFERENT node sets; a
+ * single node implying two values on the same dimension is not a
+ * contradiction, it's just multi-faceted.
+ */
+function detectContradictions(groups) {
+  const byDim = new Map();
+  for (const g of groups) {
+    if (!byDim.has(g.dimension)) byDim.set(g.dimension, []);
+    byDim.get(g.dimension).push(g);
+  }
+
+  const contradictions = [];
+  for (const [dimension, dimGroups] of byDim.entries()) {
+    if (dimGroups.length < 2) continue;
+    for (let i = 0; i < dimGroups.length - 1; i++) {
+      for (let j = i + 1; j < dimGroups.length; j++) {
+        const a = dimGroups[i], b = dimGroups[j];
+        const aRefs = new Set(a.reinforcing_refs);
+        const disjoint = b.reinforcing_refs.every(r => !aRefs.has(r));
+        if (!disjoint) continue;
+        contradictions.push({
+          dimension,
+          sideA: a,
+          sideB: b,
+        });
+      }
+    }
+  }
+  return contradictions;
+}
+
+// ── Phase 4: Emergent K-way Fusion ─────────────────────────────────────────
+
+async function runFusionPass(nodes, llmClient, model, opts) {
+  const samples = [];
+  const sampleCount = Math.min(opts.fusionSamples, Math.floor(nodes.length / opts.k));
+  if (sampleCount <= 0) return [];
+
+  const usedCounts = new Map();
+  for (let i = 0; i < sampleCount; i++) {
+    const sample = sampleAcrossDomains(nodes, opts.k, usedCounts, opts.domainSpread);
+    if (sample.length < Math.min(4, opts.k)) continue;
+    for (const s of sample) usedCounts.set(s.ref, (usedCounts.get(s.ref) || 0) + 1);
+    samples.push(sample);
+  }
+
+  const results = [];
+  for (const sample of samples) {
+    const prompt = buildFusionPrompt(sample);
+    try {
+      const res = await llmClient.messages.create({
+        model,
+        max_tokens: 1500,
+        messages: [{ role: 'user', content: prompt }],
+      });
+      const text = res.content?.[0]?.text || res.content || '';
+      const parsed = _parseJSON(text, 'fusion');
+      if (!parsed || parsed.label === null) continue;
+      if (typeof parsed.label !== 'string') continue;
+      results.push({
+        ...parsed,
+        source_refs: sample.map(s => s.ref),
+      });
+    } catch (err) {
+      console.error('[TraitSynthesis] fusion call failed:', err.message);
+    }
+  }
+  return results;
+}
+
+/**
+ * Pick k nodes that collectively span as many distinct domains as possible,
+ * preferring nodes not yet heavily reused. Domain is unknown at this stage
+ * (it's assigned by Phase 1 via LLM). We approximate domain spread by node
+ * type + a rough topic bucketing; the fusion LLM call re-classifies anyway.
+ */
+function sampleAcrossDomains(nodes, k, usedCounts, domainSpread) {
+  const pool = [...nodes].sort((a, b) => {
+    const ua = usedCounts.get(a.ref) || 0;
+    const ub = usedCounts.get(b.ref) || 0;
+    if (ua !== ub) return ua - ub;
+    return Math.random() - 0.5;
+  });
+
+  if (!domainSpread) return pool.slice(0, k);
+
+  const picked = [];
+  const typesSeen = new Set();
+  for (const n of pool) {
+    if (picked.length >= k) break;
+    if (!typesSeen.has(n.type) || picked.length >= Math.min(3, k)) {
+      picked.push(n);
+      typesSeen.add(n.type);
+    }
+  }
+  for (const n of pool) {
+    if (picked.length >= k) break;
+    if (!picked.includes(n)) picked.push(n);
+  }
+  return picked.slice(0, k);
+}
+
+function buildFusionPrompt(sample) {
+  const lines = sample.map(n => `  - [${n.ref}] ${n.text}`);
+  return `You are looking at a set of facts about a person drawn from different life domains. Find ONE cross-domain pattern that no single fact reveals on its own, if there is one.
+
+FACTS:
+${lines.join('\n')}
+
+Rules:
+- Return one gestalt pattern that only emerges when several of these facts are considered together.
+- If the facts don't cohere into a single pattern, return {"label": null}. Do NOT invent.
+- "mechanics" must explain WHY the combination produces the pattern — not restate the facts.
+- affinities/aversions/predictions must be specific enough to match real content. No buzzwords.
+- Predictions must be falsifiable via observable behavior (dwell, share, skip).
+
+Respond with JSON only:
+{
+  "label":       "short human handle (3-6 words) or null",
+  "mechanics":   "2-4 sentences on WHY this combination produces a pattern",
+  "trait":       { "dimension": "...", "value": "...", "weight": 0.0-1.0 },
+  "affinities":  ["content type 1", "content type 2", ...],
+  "aversions":   ["content to avoid 1", ...],
+  "predictions": ["falsifiable observation 1", ...],
+  "domains_bridged": ["domain1", "domain2", ...],
+  "surprising":  true,
+  "confidence":  0.0-1.0
+}`;
+}
+
+// ── Composition: turn Phase 2/3/4 outputs into Synthesis records ───────────
+
+function composeReplicationSyntheses(groups, opts) {
+  const out = [];
+  for (const g of groups) {
+    const finalConf = clamp(g.base_conf + g.replication_bonus, 0, 1);
+    if (finalConf < opts.minConfidence) continue;
+
+    const origin = g.isolated ? 'single_node' : 'trait_replication';
+    const label = buildTraitLabel(g);
+
+    out.push({
+      label,
+      origin,
+      trait: { dimension: g.dimension, value: g.value, weight: round2(g.weight) },
+      mechanics: buildTraitMechanics(g),
+      reinforcing_nodes: g.reinforcing_refs,
+      domains_bridged:   g.domains_bridged,
+      contradicting_nodes: [],
+      isolated:  g.isolated,
+      confidence: round2(finalConf),
+      confidence_components: {
+        base_from_llm:         round2(g.base_conf),
+        replication_bonus:     round2(g.replication_bonus),
+        contradiction_penalty: 0,
+        cross_domain:          g.cross_domain,
+      },
+      affinities:  [],
+      aversions:   [],
+      predictions: [],
+      surprising:  false,
+      mode: 'trait_synthesis',
+    });
+  }
+  return out;
+}
+
+function composeContradictionSyntheses(contradictions, opts) {
+  const out = [];
+  for (const c of contradictions) {
+    const { sideA, sideB } = c;
+    const combinedBase = avg([sideA.base_conf, sideB.base_conf]);
+    const penalty = Math.min(
+      0.5,
+      opts.gamma * Math.min(sideA.reinforcing_refs.length, sideB.reinforcing_refs.length)
+    );
+    const finalConf = clamp(combinedBase - penalty, 0, 1);
+    if (finalConf < opts.minConfidence) continue;
+
+    const label = `Conflicting signals on ${c.dimension.replace(/_/g, ' ')}`;
+    const mechanics =
+      `On dimension "${c.dimension}" the user's facts diverge: ` +
+      `${sideA.reinforcing_refs.join(', ')} imply "${sideA.value}", while ` +
+      `${sideB.reinforcing_refs.join(', ')} imply "${sideB.value}". ` +
+      `Downstream tools should treat this as an aspirational-vs-actual gap or a genuine complexity, not a single coherent trait.`;
+
+    out.push({
+      label,
+      origin: 'contradiction',
+      trait: { dimension: c.dimension, value: `${sideA.value}↔${sideB.value}`, weight: round2(avg([sideA.weight, sideB.weight])) },
+      mechanics,
+      reinforcing_nodes:   sideA.reinforcing_refs,
+      contradicting_nodes: sideB.reinforcing_refs,
+      domains_bridged:     [...new Set([...sideA.domains_bridged, ...sideB.domains_bridged])],
+      isolated: false,
+      confidence: round2(finalConf),
+      confidence_components: {
+        base_from_llm:         round2(combinedBase),
+        replication_bonus:     0,
+        contradiction_penalty: round2(penalty),
+        cross_domain:          (sideA.cross_domain || sideB.cross_domain),
+      },
+      affinities:  [],
+      aversions:   [],
+      predictions: [],
+      surprising:  true,
+      mode: 'trait_synthesis',
+    });
+  }
+  return out;
+}
+
+function composeFusionSyntheses(fusions, opts) {
+  const out = [];
+  for (const f of fusions) {
+    const conf = clamp(Number(f.confidence ?? 0.5), 0, 1);
+    if (conf < opts.minConfidence) continue;
+    if (opts.schemaStrict) {
+      if (!f.trait || !f.trait.dimension || !f.trait.value) continue;
+      if (typeof f.mechanics !== 'string' || f.mechanics.length < 20) continue;
+    }
+    if (opts.requireSurprising && !f.surprising) continue;
+
+    out.push({
+      label: f.label,
+      origin: 'emergent_fusion',
+      trait: {
+        dimension: String(f.trait.dimension).toLowerCase().trim(),
+        value:     String(f.trait.value).toLowerCase().trim(),
+        weight:    clamp(Number(f.trait.weight ?? 0.7), 0, 1),
+      },
+      mechanics: f.mechanics,
+      reinforcing_nodes:   f.source_refs || [],
+      contradicting_nodes: [],
+      domains_bridged:     Array.isArray(f.domains_bridged) ? f.domains_bridged.map(d => String(d).toLowerCase()) : [],
+      isolated: false,
+      confidence: round2(conf),
+      confidence_components: {
+        base_from_llm:         round2(conf),
+        replication_bonus:     0,
+        contradiction_penalty: 0,
+        cross_domain:          (Array.isArray(f.domains_bridged) && f.domains_bridged.length > 1),
+      },
+      affinities:  Array.isArray(f.affinities)  ? f.affinities.slice(0, 8).map(String)  : [],
+      aversions:   Array.isArray(f.aversions)   ? f.aversions.slice(0, 8).map(String)   : [],
+      predictions: Array.isArray(f.predictions) ? f.predictions.slice(0, 8).map(String) : [],
+      surprising:  !!f.surprising,
+      mode: 'fusion',
+    });
+  }
+  return out;
+}
+
+// ── Label/Mechanics helpers ────────────────────────────────────────────────
+
+function buildTraitLabel(g) {
+  const d = g.dimension.replace(/_/g, ' ');
+  const v = g.value.replace(/_/g, ' ');
+  if (g.isolated) return `Isolated signal — ${d}: ${v}`;
+  if (g.cross_domain) return `Replicated across ${g.domains_bridged.length} domains — ${d}: ${v}`;
+  return `Replicated — ${d}: ${v}`;
+}
+
+function buildTraitMechanics(g) {
+  if (g.isolated) {
+    const only = g.reinforcing_refs[0];
+    return `The trait "${g.dimension} = ${g.value}" is implied by a single fact (${only}). No replication across other domains yet, so the signal is moderate at best — it may be real but cannot be confirmed by cross-domain coherence.`;
+  }
+  const refs = g.reinforcing_refs.join(', ');
+  const doms = g.domains_bridged.join(', ') || 'a single domain';
+  return `The trait "${g.dimension} = ${g.value}" is independently implied by ${g.reinforcing_refs.length} facts (${refs}) spanning ${doms}. Replication across distinct facts raises confidence beyond what any single fact would support.`;
+}
+
+// ── Utilities ──────────────────────────────────────────────────────────────
+
+function clamp(v, lo, hi) { return Math.max(lo, Math.min(hi, v)); }
+function avg(xs) { return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length; }
+function round2(x) { return Math.round(x * 100) / 100; }
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Run trait-based synthesis against a KG. Returns Synthesis[].
+ *
+ * The caller is responsible for persisting results (e.g. `kg.addSynthesis`) —
+ * this function is pure w.r.t. the KG.
+ *
+ * @param {import('./kg.js').KnowledgeGraph} kg
+ * @param {Object} [opts]
+ * @param {Object} [opts.llmClient]
+ * @param {string} [opts.model]
+ * @param {boolean} [opts.perNodeExtraction=true]
+ * @param {number}  [opts.extractionChunkSize=10]
+ * @param {number}  [opts.fusionSamples=5]
+ * @param {number}  [opts.k=10]
+ * @param {boolean} [opts.contradictionScan=true]
+ * @param {boolean} [opts.domainSpread=true]
+ * @param {number[]} [opts.strengthRange=[0.4, 0.9]]
+ * @param {number}  [opts.alpha=0.15]
+ * @param {number}  [opts.beta=1.3]
+ * @param {number}  [opts.gamma=0.2]
+ * @param {boolean} [opts.requireSurprising=false]
+ * @param {number}  [opts.minConfidence=0.4]
+ * @param {boolean} [opts.schemaStrict=true]
+ * @returns {Promise<Synthesis[]>}
+ */
+export async function runTraitSynthesis(kg, opts = {}) {
+  const mergedOpts = { ...DEFAULTS, ...opts };
+  const llmClient = opts.llmClient || createLLMClient();
+  const model     = opts.model || llmClient.defaultModel?.('heavy') || 'default';
+
+  const nodes = collectNodes(kg, mergedOpts.strengthRange);
+  if (nodes.length === 0) return [];
+
+  // Phase 1
+  const candidates = mergedOpts.perNodeExtraction
+    ? await extractTraits(nodes, llmClient, model, mergedOpts)
+    : [];
+
+  // Phase 2
+  const groups = groupByReplication(candidates, mergedOpts);
+
+  // Phase 3
+  const contradictions = mergedOpts.contradictionScan
+    ? detectContradictions(groups)
+    : [];
+
+  // Phase 4
+  const fusions = mergedOpts.fusionSamples > 0
+    ? await runFusionPass(nodes, llmClient, model, mergedOpts)
+    : [];
+
+  // Compose + dedup by trait key
+  const all = [
+    ...composeReplicationSyntheses(groups, mergedOpts),
+    ...composeContradictionSyntheses(contradictions, mergedOpts),
+    ...composeFusionSyntheses(fusions, mergedOpts),
+  ];
+
+  return dedupAndRank(all);
+}
+
+function dedupAndRank(list) {
+  const seen = new Map();
+  for (const s of list) {
+    const key = `${s.origin}|${s.trait.dimension}|${s.trait.value}`;
+    const existing = seen.get(key);
+    if (!existing || s.confidence > existing.confidence) seen.set(key, s);
+  }
+  return [...seen.values()].sort((a, b) => b.confidence - a.confidence);
+}
+
+// Exposed for tests
+export const _internal = {
+  collectNodes,
+  groupByReplication,
+  detectContradictions,
+  composeReplicationSyntheses,
+  composeContradictionSyntheses,
+  composeFusionSyntheses,
+  dedupAndRank,
+  sampleAcrossDomains,
+  _parseJSON,
+};

--- a/core/types.js
+++ b/core/types.js
@@ -407,6 +407,51 @@ export const CALIBRATION_STATUS = {
  * @property {'active'|'killed'} status
  */
 
+/**
+ * @typedef {Object} SynthesisTrait
+ * @property {string} dimension  - e.g. "time_orientation", "effort_profile"
+ * @property {string} value      - e.g. "compound", "peak_driven"
+ * @property {number} weight     - 0-1, how strongly this trait applies
+ */
+
+/**
+ * @typedef {Object} ConfidenceComponents
+ * @property {number}  base_from_llm        - LLM-stated confidence for the trait
+ * @property {number}  replication_bonus    - Bonus from cross-node reinforcement
+ * @property {number}  contradiction_penalty - Penalty from contradicting evidence
+ * @property {boolean} cross_domain         - Reinforcing nodes span >1 domain
+ */
+
+/**
+ * @typedef {'single_node'|'trait_replication'|'contradiction'|'emergent_fusion'} SynthesisOrigin
+ *   - single_node: trait implied by exactly one node — low confidence by design
+ *   - trait_replication: same trait implied by multiple nodes, optionally across domains
+ *   - contradiction: same dimension, divergent values from disjoint node sets
+ *   - emergent_fusion: gestalt pattern from K-way cross-domain sample; no single-node derivation
+ */
+
+/**
+ * @typedef {Object} Synthesis
+ * @property {string}   id                    - Stable record id
+ * @property {string}   label                 - Short human handle (not the payload)
+ * @property {SynthesisOrigin} origin
+ * @property {SynthesisTrait}  trait
+ * @property {string}   mechanics             - 2-4 sentences explaining WHY this pattern coheres
+ * @property {string[]} reinforcing_nodes     - Node refs that support the trait (e.g. "belief:running")
+ * @property {string[]} contradicting_nodes   - Node refs that undermine it (contradiction case only)
+ * @property {string[]} domains_bridged       - Unique domains across reinforcing nodes
+ * @property {boolean}  isolated              - True when only one node supports the trait
+ * @property {number}   confidence            - Final composite confidence 0-1
+ * @property {ConfidenceComponents} confidence_components
+ * @property {string[]} affinities            - Content types that should match this pattern
+ * @property {string[]} aversions             - Content types that should be deprioritized
+ * @property {string[]} predictions           - Falsifiable observable behaviors
+ * @property {boolean}  surprising            - Flagged as non-obvious (useful for ranking)
+ * @property {string}   generated_at          - ISO timestamp
+ * @property {string}   [model]               - LLM model id used
+ * @property {string}   mode                  - Which engine mode emitted this ("trait_synthesis" | "fusion")
+ */
+
 export const EXTENDED_USE_CASE_CONFIGS = {
   ...USE_CASE_CONFIGS,
   ecommerce: {

--- a/test/trait-synthesis.test.js
+++ b/test/trait-synthesis.test.js
@@ -1,0 +1,534 @@
+/**
+ * trait-synthesis.test.js
+ *
+ * Covers the L2 trait synthesis pipeline end-to-end:
+ *   - Phase 1  per-node trait extraction with a queued mock LLM
+ *   - Phase 2  replication grouping (in-process, no LLM)
+ *   - Phase 3  contradiction detection (in-process, no LLM)
+ *   - Phase 4  K-way emergent fusion with a queued mock LLM
+ *   - KG persistence (addSynthesis upsert, accessors)
+ *   - Marble.synthesize() public wrapper
+ *
+ * All LLM calls are routed through a deterministic queue so the tests are
+ * hermetic — no network, no API key required.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Marble } from '../core/index.js';
+import { KnowledgeGraph } from '../core/kg.js';
+import { wrapUserLLM } from '../core/llm-provider.js';
+import { runTraitSynthesis, _internal } from '../core/trait-synthesis.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function tmpKgPath() {
+  const dir = mkdtempSync(join(tmpdir(), 'marble-trait-'));
+  return { path: join(dir, 'kg.json'), cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * Build a client that returns a queue of pre-fabricated JSON string responses
+ * in order. Raises if the caller exhausts the queue (surfaces test drift
+ * immediately rather than silently returning empty).
+ */
+function queuedLLM(responses) {
+  let idx = 0;
+  const fn = async () => {
+    if (idx >= responses.length) {
+      throw new Error(`queuedLLM: exhausted after ${responses.length} calls`);
+    }
+    const out = responses[idx++];
+    return out;
+  };
+  fn.index = () => idx;
+  return { client: wrapUserLLM(fn), calls: fn };
+}
+
+/**
+ * Lightweight KG with a given set of L1 nodes. Used by the in-process tests
+ * that don't need a file-backed KG.
+ */
+function makeKg({ beliefs = [], preferences = [], identities = [] } = {}) {
+  const kg = new KnowledgeGraph(':memory:');
+  kg.user = {
+    id: 'test',
+    interests: [],
+    context: {},
+    history: [],
+    source_trust: {},
+    beliefs:     beliefs.map(b => ({ strength: 0.7, valid_to: null, ...b })),
+    preferences: preferences.map(p => ({ strength: 0.7, valid_to: null, ...p })),
+    identities:  identities.map(i => ({ salience: 0.8, valid_to: null, ...i })),
+    confidence: {},
+    clones: [],
+    episodes: [],
+    entities: [],
+    insights: [],
+    syntheses: [],
+  };
+  return kg;
+}
+
+// ── collectNodes ───────────────────────────────────────────────────────────
+
+describe('collectNodes', () => {
+  it('collects active beliefs/preferences/identities with stable refs', () => {
+    const kg = makeKg({
+      beliefs:     [{ topic: 'running', claim: 'enjoys long runs', strength: 0.7 }],
+      preferences: [{ type: 'pace', description: 'slow', strength: 0.6 }],
+      identities:  [{ role: 'founder', context: 'Barcelona', salience: 0.85 }],
+    });
+    const nodes = _internal.collectNodes(kg, [0.4, 0.9]);
+
+    const refs = nodes.map(n => n.ref);
+    assert.deepEqual(refs.sort(), ['belief:running', 'identity:founder', 'preference:pace']);
+    assert.ok(nodes.every(n => typeof n.text === 'string' && n.text.length > 0));
+  });
+
+  it('drops out-of-range strengths and expired (valid_to) nodes', () => {
+    const kg = makeKg({
+      beliefs: [
+        { topic: 'too_strong',  claim: 'x', strength: 0.95 },
+        { topic: 'too_weak',    claim: 'x', strength: 0.3 },
+        { topic: 'retired',     claim: 'x', strength: 0.7, valid_to: '2020-01-01' },
+        { topic: 'just_right',  claim: 'x', strength: 0.6 },
+      ],
+    });
+    const nodes = _internal.collectNodes(kg, [0.4, 0.9]);
+    assert.deepEqual(nodes.map(n => n.ref), ['belief:just_right']);
+  });
+});
+
+// ── groupByReplication ─────────────────────────────────────────────────────
+
+describe('groupByReplication', () => {
+  const opts = { alpha: 0.15, beta: 1.3 };
+
+  it('groups identical (dimension, value) pairs and marks isolation correctly', () => {
+    const candidates = [
+      { node_ref: 'belief:running',       domain: 'health',       dimension: 'time_orientation', value: 'compound', weight: 0.7, base_conf: 0.6 },
+      { node_ref: 'identity:daily_prayer', domain: 'spirituality', dimension: 'time_orientation', value: 'compound', weight: 0.8, base_conf: 0.7 },
+      { node_ref: 'preference:pace',      domain: 'health',       dimension: 'effort_profile',   value: 'sustained_low', weight: 0.7, base_conf: 0.6 },
+    ];
+    const groups = _internal.groupByReplication(candidates, opts);
+    const timeGroup = groups.find(g => g.dimension === 'time_orientation');
+    const effortGroup = groups.find(g => g.dimension === 'effort_profile');
+
+    assert.equal(timeGroup.reinforcing_refs.length, 2);
+    assert.equal(timeGroup.isolated, false);
+    assert.equal(timeGroup.cross_domain, true);
+    assert.ok(timeGroup.replication_bonus > 0);
+
+    assert.equal(effortGroup.reinforcing_refs.length, 1);
+    assert.equal(effortGroup.isolated, true);
+    assert.equal(effortGroup.cross_domain, false);
+    assert.equal(effortGroup.replication_bonus > 0, true);  // single-node still gets log(1+1) bonus
+  });
+
+  it('dedupes duplicate candidates from the same node', () => {
+    const candidates = [
+      { node_ref: 'belief:x', domain: 'work', dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+      { node_ref: 'belief:x', domain: 'work', dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+    ];
+    const [g] = _internal.groupByReplication(candidates, opts);
+    assert.equal(g.reinforcing_refs.length, 1, 'same node must not double-count');
+  });
+
+  it('cross-domain replication bonus exceeds same-domain replication bonus', () => {
+    const sameDomain = _internal.groupByReplication([
+      { node_ref: 'belief:a', domain: 'health', dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+      { node_ref: 'belief:b', domain: 'health', dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+    ], opts);
+    const crossDomain = _internal.groupByReplication([
+      { node_ref: 'belief:a', domain: 'health', dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+      { node_ref: 'belief:b', domain: 'work',   dimension: 'd', value: 'v', weight: 0.7, base_conf: 0.6 },
+    ], opts);
+    assert.ok(crossDomain[0].replication_bonus > sameDomain[0].replication_bonus);
+  });
+});
+
+// ── detectContradictions ───────────────────────────────────────────────────
+
+describe('detectContradictions', () => {
+  it('emits a contradiction when same dimension has divergent values from disjoint node sets', () => {
+    const groups = [
+      { dimension: 'follow_through', value: 'sustained',    reinforcing_refs: ['belief:run', 'identity:prayer'], domains_bridged: ['health','spirituality'], base_conf: 0.7, weight: 0.8, cross_domain: true, isolated: false, replication_bonus: 0.2 },
+      { dimension: 'follow_through', value: 'inconsistent', reinforcing_refs: ['history:quit_3', 'history:jobhops'], domains_bridged: ['work'], base_conf: 0.65, weight: 0.7, cross_domain: false, isolated: false, replication_bonus: 0.1 },
+    ];
+    const contradictions = _internal.detectContradictions(groups);
+    assert.equal(contradictions.length, 1);
+    assert.equal(contradictions[0].dimension, 'follow_through');
+    assert.ok(contradictions[0].sideA && contradictions[0].sideB);
+  });
+
+  it('skips pairs that share reinforcing nodes — overlap is complexity, not contradiction', () => {
+    const groups = [
+      { dimension: 'd', value: 'a', reinforcing_refs: ['belief:x', 'belief:y'], domains_bridged: ['w'], base_conf: 0.6, weight: 0.7, cross_domain: false, isolated: false, replication_bonus: 0.1 },
+      { dimension: 'd', value: 'b', reinforcing_refs: ['belief:y', 'belief:z'], domains_bridged: ['w'], base_conf: 0.6, weight: 0.7, cross_domain: false, isolated: false, replication_bonus: 0.1 },
+    ];
+    assert.equal(_internal.detectContradictions(groups).length, 0);
+  });
+
+  it('returns empty when a dimension has only one value', () => {
+    const groups = [
+      { dimension: 'd', value: 'v', reinforcing_refs: ['a', 'b'], domains_bridged: ['x'], base_conf: 0.6, weight: 0.7, cross_domain: false, isolated: false, replication_bonus: 0 },
+    ];
+    assert.deepEqual(_internal.detectContradictions(groups), []);
+  });
+});
+
+// ── Composition ────────────────────────────────────────────────────────────
+
+describe('composition: replication syntheses', () => {
+  const opts = { minConfidence: 0.4 };
+
+  it('emits origin=trait_replication for multi-node groups and origin=single_node for isolated', () => {
+    const replicated = [{
+      dimension: 'd', value: 'v', weight: 0.8,
+      reinforcing_refs: ['belief:a', 'belief:b'],
+      domains_bridged: ['health', 'work'],
+      base_conf: 0.65, replication_bonus: 0.22,
+      cross_domain: true, isolated: false,
+    }];
+    const isolated = [{
+      dimension: 'd2', value: 'v2', weight: 0.5,
+      reinforcing_refs: ['belief:only'],
+      domains_bridged: ['hobbies'],
+      base_conf: 0.55, replication_bonus: 0.05,
+      cross_domain: false, isolated: true,
+    }];
+    const [r] = _internal.composeReplicationSyntheses(replicated, opts);
+    const [i] = _internal.composeReplicationSyntheses(isolated, opts);
+
+    assert.equal(r.origin, 'trait_replication');
+    assert.equal(r.confidence, 0.87);
+    assert.equal(r.confidence_components.cross_domain, true);
+    assert.equal(r.confidence_components.replication_bonus, 0.22);
+    assert.equal(i.origin, 'single_node');
+    assert.equal(i.isolated, true);
+  });
+
+  it('drops syntheses below opts.minConfidence', () => {
+    const groups = [{
+      dimension: 'd', value: 'v', weight: 0.4,
+      reinforcing_refs: ['belief:weak'],
+      domains_bridged: ['x'],
+      base_conf: 0.2, replication_bonus: 0.05,
+      cross_domain: false, isolated: true,
+    }];
+    assert.deepEqual(_internal.composeReplicationSyntheses(groups, { minConfidence: 0.5 }), []);
+  });
+});
+
+describe('composition: contradiction syntheses', () => {
+  const opts = { minConfidence: 0.3, gamma: 0.2 };
+
+  it('penalizes confidence by contradiction_penalty and keeps both node sides', () => {
+    const contradictions = [{
+      dimension: 'follow_through',
+      sideA: { value: 'sustained',    reinforcing_refs: ['a', 'b'], domains_bridged: ['health'], base_conf: 0.7, weight: 0.8, cross_domain: false, isolated: false, replication_bonus: 0.1 },
+      sideB: { value: 'inconsistent', reinforcing_refs: ['c'],       domains_bridged: ['work'],    base_conf: 0.65, weight: 0.7, cross_domain: false, isolated: true,  replication_bonus: 0 },
+    }];
+    const [s] = _internal.composeContradictionSyntheses(contradictions, opts);
+
+    assert.equal(s.origin, 'contradiction');
+    assert.deepEqual(s.reinforcing_nodes, ['a', 'b']);
+    assert.deepEqual(s.contradicting_nodes, ['c']);
+    assert.equal(s.confidence_components.contradiction_penalty > 0, true);
+    assert.equal(s.surprising, true);
+    assert.ok(s.domains_bridged.includes('health') && s.domains_bridged.includes('work'));
+  });
+});
+
+describe('composition: fusion syntheses', () => {
+  const baseFusion = {
+    label: 'Endurance-engineered founder',
+    mechanics: 'Long-horizon disciplines across health, spirituality, and work share the same psychological toolkit of delayed gratification.',
+    trait: { dimension: 'time_orientation', value: 'compound', weight: 0.85 },
+    affinities: ['marathon essays', 'stoicism'],
+    aversions: ['hustle porn'],
+    predictions: ['dwells 2x on endurance content'],
+    domains_bridged: ['health', 'spirituality', 'work'],
+    surprising: true,
+    confidence: 0.72,
+    source_refs: ['belief:running', 'identity:prayer', 'preference:5yr_positions'],
+  };
+
+  it('passes a well-formed fusion through with origin=emergent_fusion', () => {
+    const [s] = _internal.composeFusionSyntheses([baseFusion], { minConfidence: 0.4, schemaStrict: true, requireSurprising: false });
+    assert.equal(s.origin, 'emergent_fusion');
+    assert.equal(s.trait.dimension, 'time_orientation');
+    assert.equal(s.mode, 'fusion');
+    assert.deepEqual(s.reinforcing_nodes, baseFusion.source_refs);
+    assert.equal(s.surprising, true);
+  });
+
+  it('rejects fusion missing trait under schemaStrict', () => {
+    const bad = { ...baseFusion, trait: null };
+    assert.deepEqual(
+      _internal.composeFusionSyntheses([bad], { minConfidence: 0.4, schemaStrict: true, requireSurprising: false }),
+      []
+    );
+  });
+
+  it('drops non-surprising when requireSurprising=true', () => {
+    const meh = { ...baseFusion, surprising: false };
+    assert.deepEqual(
+      _internal.composeFusionSyntheses([meh], { minConfidence: 0.4, schemaStrict: true, requireSurprising: true }),
+      []
+    );
+  });
+});
+
+// ── sampleAcrossDomains ────────────────────────────────────────────────────
+
+describe('sampleAcrossDomains', () => {
+  it('prefers domain spread when enabled', () => {
+    const nodes = [
+      { ref: 'belief:a',     type: 'belief',     text: 'a', strength: 0.7 },
+      { ref: 'belief:b',     type: 'belief',     text: 'b', strength: 0.7 },
+      { ref: 'preference:a', type: 'preference', text: 'a', strength: 0.7 },
+      { ref: 'preference:b', type: 'preference', text: 'b', strength: 0.7 },
+      { ref: 'identity:a',   type: 'identity',   text: 'a', strength: 0.7 },
+    ];
+    const sample = _internal.sampleAcrossDomains(nodes, 3, new Map(), true);
+    const types = new Set(sample.map(s => s.type));
+    assert.equal(sample.length, 3);
+    assert.equal(types.size, 3, 'should pick one from each type before backfilling');
+  });
+
+  it('honors usedCounts — less-used nodes picked first', () => {
+    const nodes = [
+      { ref: 'a', type: 'belief', text: 'a', strength: 0.7 },
+      { ref: 'b', type: 'belief', text: 'b', strength: 0.7 },
+    ];
+    const used = new Map([['a', 5], ['b', 0]]);
+    const [first] = _internal.sampleAcrossDomains(nodes, 1, used, false);
+    assert.equal(first.ref, 'b');
+  });
+});
+
+// ── _parseJSON ─────────────────────────────────────────────────────────────
+
+describe('_parseJSON', () => {
+  it('parses raw JSON', () => {
+    assert.deepEqual(_internal._parseJSON('{"a":1}'), { a: 1 });
+  });
+  it('parses fenced JSON', () => {
+    assert.deepEqual(_internal._parseJSON('```json\n{"a":2}\n```'), { a: 2 });
+  });
+  it('extracts JSON from surrounding prose', () => {
+    assert.deepEqual(_internal._parseJSON('here you go: {"a":3} thanks'), { a: 3 });
+  });
+  it('returns null on unparseable input', () => {
+    assert.equal(_internal._parseJSON('this has no json'), null);
+  });
+});
+
+// ── KG persistence ─────────────────────────────────────────────────────────
+
+describe('kg.addSynthesis / getSyntheses / getSynthesesForNode', () => {
+  it('assigns an id + generated_at if missing, upserts on (origin, trait.dim, trait.val)', () => {
+    const kg = makeKg();
+    const a = kg.addSynthesis({
+      origin: 'trait_replication',
+      trait: { dimension: 'd', value: 'v', weight: 0.7 },
+      confidence: 0.6,
+      reinforcing_nodes: ['belief:x'],
+      domains_bridged: ['health'],
+    });
+    assert.ok(a.id);
+    assert.ok(a.generated_at);
+
+    // Higher-confidence write on same key replaces (keeping original id)
+    const b = kg.addSynthesis({
+      origin: 'trait_replication',
+      trait: { dimension: 'd', value: 'v', weight: 0.8 },
+      confidence: 0.8,
+      reinforcing_nodes: ['belief:x', 'belief:y'],
+      domains_bridged: ['health', 'work'],
+    });
+    assert.equal(b.id, a.id, 'upsert must preserve the original id');
+    assert.equal(kg.user.syntheses.length, 1);
+    assert.equal(kg.user.syntheses[0].confidence, 0.8);
+
+    // Lower-confidence write on same key is ignored
+    kg.addSynthesis({
+      origin: 'trait_replication',
+      trait: { dimension: 'd', value: 'v', weight: 0.1 },
+      confidence: 0.1,
+      reinforcing_nodes: [],
+      domains_bridged: [],
+    });
+    assert.equal(kg.user.syntheses[0].confidence, 0.8, 'lower-confidence write should not overwrite');
+  });
+
+  it('filters by origin, minConfidence, surprising, trait, and domainsIncludes', () => {
+    const kg = makeKg();
+    kg.addSynthesis({ origin: 'single_node',        trait: { dimension: 'd1', value: 'v1', weight: 0.5 }, confidence: 0.5, surprising: false, domains_bridged: ['health'],        reinforcing_nodes: ['belief:a'] });
+    kg.addSynthesis({ origin: 'trait_replication',  trait: { dimension: 'd1', value: 'v2', weight: 0.7 }, confidence: 0.8, surprising: false, domains_bridged: ['health', 'work'], reinforcing_nodes: ['belief:a', 'belief:b'] });
+    kg.addSynthesis({ origin: 'contradiction',      trait: { dimension: 'd2', value: 'x↔y', weight: 0.6 }, confidence: 0.65, surprising: true, domains_bridged: ['work'],          reinforcing_nodes: ['belief:c'], contradicting_nodes: ['belief:d'] });
+
+    assert.equal(kg.getSyntheses({ minConfidence: 0.7 }).length, 1);
+    assert.equal(kg.getSyntheses({ origin: 'contradiction' }).length, 1);
+    assert.equal(kg.getSyntheses({ surprising: true }).length, 1);
+    assert.equal(kg.getSyntheses({ trait: { dimension: 'd1' } }).length, 2);
+    assert.equal(kg.getSyntheses({ domainsIncludes: ['health', 'work'] }).length, 1);
+  });
+
+  it('getSynthesesForNode returns records from both reinforcing and contradicting sides', () => {
+    const kg = makeKg();
+    kg.addSynthesis({ origin: 'contradiction', trait: { dimension: 'd', value: 'a↔b', weight: 0.6 }, confidence: 0.6, reinforcing_nodes: ['belief:r'], contradicting_nodes: ['belief:c'], domains_bridged: [] });
+    assert.equal(kg.getSynthesesForNode('belief:r').length, 1);
+    assert.equal(kg.getSynthesesForNode('belief:c').length, 1);
+    assert.equal(kg.getSynthesesForNode('belief:absent').length, 0);
+  });
+});
+
+// ── End-to-end with mocked LLM ─────────────────────────────────────────────
+
+describe('runTraitSynthesis end-to-end (mocked LLM)', () => {
+  it('produces replication + contradiction + fusion origins from a crafted KG', async () => {
+    const kg = makeKg({
+      beliefs:     [{ topic: 'running', claim: 'enjoys long Higdon-style runs', strength: 0.7 }],
+      preferences: [{ type: 'positions', description: 'holds 5+ years', strength: 0.7 }],
+      identities:  [
+        { role: 'daily_prayer', context: 'consistent 3yr practice', salience: 0.75 },
+        { role: 'serial_quitter', context: 'abandons side-projects at 4mo', salience: 0.7 },
+      ],
+    });
+
+    // Phase 1 response: one per extraction chunk. With chunkSize=10 (default)
+    // and 4 nodes, there's exactly one chunk — one LLM call.
+    const extraction = JSON.stringify([
+      { node_ref: 'belief:running', domain: 'health',       traits: [
+        { dimension: 'time_orientation', value: 'compound', weight: 0.75, confidence: 0.7, evidence_quote: 'long runs' },
+      ]},
+      { node_ref: 'preference:positions', domain: 'finance',      traits: [
+        { dimension: 'time_orientation', value: 'compound', weight: 0.8,  confidence: 0.75, evidence_quote: '5+ years' },
+      ]},
+      { node_ref: 'identity:daily_prayer', domain: 'spirituality', traits: [
+        { dimension: 'time_orientation', value: 'compound', weight: 0.7,  confidence: 0.65, evidence_quote: 'consistent 3yr' },
+        { dimension: 'follow_through',   value: 'sustained', weight: 0.8, confidence: 0.75, evidence_quote: 'consistent' },
+      ]},
+      { node_ref: 'identity:serial_quitter', domain: 'work',      traits: [
+        { dimension: 'follow_through',   value: 'inconsistent', weight: 0.8, confidence: 0.75, evidence_quote: 'abandons at 4mo' },
+      ]},
+    ]);
+
+    // Phase 4 response — one fusion call (fusionSamples=5 capped by floor(N/k)).
+    // With k=3 and 4 nodes, floor(4/3)=1 — one fusion call.
+    const fusion = JSON.stringify({
+      label:       'Endurance-engineered discipline',
+      mechanics:   'Long-horizon practices span health, spirituality, and finance using the same psychological toolkit of delayed gratification and repetition without stimulation.',
+      trait:       { dimension: 'effort_profile', value: 'sustained_low_intensity', weight: 0.8 },
+      affinities:  ['marathon essays', 'contemplative practice content'],
+      aversions:   ['hustle porn'],
+      predictions: ['dwells >2x on endurance content'],
+      domains_bridged: ['health', 'spirituality', 'finance'],
+      surprising:  true,
+      confidence:  0.72,
+    });
+
+    const { client } = queuedLLM([extraction, fusion]);
+
+    const syntheses = await runTraitSynthesis(kg, {
+      llmClient: client,
+      k: 3,
+      fusionSamples: 5,
+      minConfidence: 0.4,
+    });
+
+    const origins = syntheses.map(s => s.origin);
+    assert.ok(origins.includes('trait_replication'), 'missing trait_replication origin');
+    assert.ok(origins.includes('contradiction'),     'missing contradiction origin');
+    assert.ok(origins.includes('emergent_fusion'),   'missing emergent_fusion origin');
+
+    const replication = syntheses.find(s => s.origin === 'trait_replication');
+    assert.equal(replication.trait.dimension, 'time_orientation');
+    assert.equal(replication.trait.value, 'compound');
+    assert.equal(replication.reinforcing_nodes.length, 3);
+    assert.equal(replication.confidence_components.cross_domain, true);
+    assert.ok(replication.confidence > 0.7, `replicated confidence should be boosted, got ${replication.confidence}`);
+
+    const contradiction = syntheses.find(s => s.origin === 'contradiction');
+    assert.equal(contradiction.trait.dimension, 'follow_through');
+    assert.equal(contradiction.reinforcing_nodes.length, 1);
+    assert.equal(contradiction.contradicting_nodes.length, 1);
+    assert.equal(contradiction.surprising, true);
+    assert.ok(contradiction.confidence_components.contradiction_penalty > 0);
+
+    const fusionSyn = syntheses.find(s => s.origin === 'emergent_fusion');
+    assert.equal(fusionSyn.mode, 'fusion');
+    assert.ok(fusionSyn.affinities.includes('marathon essays'));
+    assert.ok(fusionSyn.aversions.includes('hustle porn'));
+    assert.equal(fusionSyn.surprising, true);
+  });
+
+  it('returns [] when no L1 nodes meet the strength range', async () => {
+    const kg = makeKg({
+      beliefs: [{ topic: 'too_weak', claim: 'x', strength: 0.2 }],
+    });
+    const { client } = queuedLLM([]);
+    const out = await runTraitSynthesis(kg, { llmClient: client });
+    assert.deepEqual(out, []);
+  });
+
+  it('gracefully handles LLM returning unparseable text (drops that chunk)', async () => {
+    const kg = makeKg({
+      beliefs: [{ topic: 'x', claim: 'y', strength: 0.6 }],
+    });
+    const { client } = queuedLLM([
+      'i am not json at all, sorry',
+      '{"label":null}',  // fusion returns null — skip
+    ]);
+    const out = await runTraitSynthesis(kg, {
+      llmClient: client,
+      fusionSamples: 1,
+      k: 1,
+    });
+    // Nothing to synthesize when extraction fails and fusion returned null.
+    assert.deepEqual(out, []);
+  });
+});
+
+// ── Marble.synthesize() public wrapper ─────────────────────────────────────
+
+describe('Marble.synthesize() public wrapper', () => {
+  it('persists syntheses to kg.user.syntheses and returns the stored records', async () => {
+    const { path, cleanup } = tmpKgPath();
+    try {
+      const extraction = JSON.stringify([
+        { node_ref: 'belief:x', domain: 'work', traits: [
+          { dimension: 'follow_through', value: 'sustained', weight: 0.7, confidence: 0.7, evidence_quote: 'ships fast' },
+        ]},
+        { node_ref: 'preference:y', domain: 'work', traits: [
+          { dimension: 'follow_through', value: 'sustained', weight: 0.75, confidence: 0.7, evidence_quote: 'no fluff' },
+        ]},
+      ]);
+      // Provide a fusion response even though the node count may not trigger
+      // a fusion call — queuedLLM will raise if over-requested, so an extra
+      // response in the queue is a test safety net rather than a requirement.
+      const fusion = JSON.stringify({ label: null });
+
+      const { client } = queuedLLM([extraction, fusion]);
+      const marble = new Marble({ storage: path, llm: null, silent: true });
+      marble.llm = client;  // bypass wrapUserLLM — we already wrapped above
+      await marble.init();
+      marble.kg.addBelief('x', 'ships fast', 0.7);
+      marble.kg.addPreference('y', 'no fluff', 0.7);
+
+      const result = await marble.synthesize({ fusionSamples: 0 });
+      assert.ok(Array.isArray(result));
+      assert.ok(result.length >= 1, 'at least one synthesis should persist');
+      assert.ok(result[0].id, 'persisted records have ids');
+      assert.ok(marble.kg.user.syntheses.length >= 1, 'kg.user.syntheses populated');
+      assert.ok(result.every(s => s.generated_at), 'generated_at set by addSynthesis');
+    } finally { cleanup(); }
+  });
+});


### PR DESCRIPTION
Closes #49.

## What

Extends L2 `InferenceEngine` with a third inference mode alongside L1.5 passthrough and pairwise L1. The **core unit is a trait with evidence**, not a K-way fused pattern. Fusion remains as a smaller add-on phase for genuinely gestalt patterns no single-node extraction would surface.

### Four phases

1. **Per-node trait extraction** (LLM, batched by chunks of ~10 nodes) — each node gets 1-3 traits with `{dimension, value, weight, confidence, evidence_quote, domain}`.
2. **Replication grouping** (in-process, no LLM) — same `(dimension, value)` across distinct nodes raises confidence; cross-domain replication multiplies the bonus.
3. **Contradiction detection** (in-process, no LLM) — same dimension, divergent values from **disjoint** node sets becomes a first-class `origin: "contradiction"` record. Overlapping sets are treated as complexity, not contradiction.
4. **K-way emergent fusion** (LLM, small number of domain-spread samples) — for patterns that only emerge from combining many nodes at once; LLM must return `{label: null}` if the facts don't cohere.

### Output schema (structured, not prose)

Every synthesis decomposes so downstream tools can match against it as predicates, not labels:

```js
{
  id, label, origin,                           // handle + "single_node"|"trait_replication"|"contradiction"|"emergent_fusion"
  trait: { dimension, value, weight },         // the matchable unit
  mechanics,                                   // why this pattern coheres (human explanation)
  reinforcing_nodes, contradicting_nodes,      // full provenance, both sides
  domains_bridged,
  isolated,
  confidence,
  confidence_components: {                      // decomposed so downstream can requery thresholds
    base_from_llm, replication_bonus,
    contradiction_penalty, cross_domain
  },
  affinities, aversions, predictions,          // specific enough to match real content; predictions are falsifiable
  surprising, generated_at, model, mode
}
```

## Public API

```js
const marble = new Marble({ llm });
await marble.learn();
await marble.investigate();
const syntheses = await marble.synthesize({ fusionSamples: 5, k: 10 });

// or directly via the engine
const engine = new InferenceEngine(kg, { llmClient });
await engine.runTraitSynthesis({ ... });

// query
kg.getSyntheses({ origin: 'contradiction' });           // aspirational-vs-actual gaps
kg.getSyntheses({ trait: { dimension: 'time_orientation' } });
kg.getSyntheses({ domainsIncludes: ['health', 'work'] });
kg.getSynthesesForNode('belief:running');               // what patterns does this fact support or undermine?
```

## Why origin matters for downstream (e.g. Vivo)

Content recommendation that only tracks positive traits will keep surfacing grit content that a user who "runs 6×/week but quits side-projects" actually rejects. Storing the contradiction as **first-class data** lets downstream tools either surface content that bridges the gap or actively deprioritize content that matches the positive trait but violates the negative one.

## Files

| File | Lines | What |
|---|---|---|
| `core/trait-synthesis.js` (new) | **606** | Pure `kg → Synthesis[]`; all four phases; prompts; parse tolerance |
| `core/kg.js` | +82 | `syntheses: []` in `#defaultUser`; `addSynthesis` upsert on `(origin, trait.dim, trait.val)`; `getSyntheses` filters; `getSynthesesForNode` |
| `core/inference-engine.js` | +27 | `runTraitSynthesis()` thin delegation that writes results through `kg.addSynthesis` |
| `core/index.js` | +25 | Public `Marble.synthesize()` — persists + saves |
| `core/types.js` | +45 | `Synthesis`, `SynthesisTrait`, `ConfidenceComponents`, `SynthesisOrigin` typedefs |
| `test/trait-synthesis.test.js` (new) | **534** | 27 hermetic tests via `wrapUserLLM` + queued mock LLM |

**Total: 1319 lines** — within the 1100-1400 range estimated in #49.

## Test plan

- [x] `npm test` — **104 pass, 0 fail** (was 77; +27 new cases)
- [x] Covers all four origins end-to-end with a crafted KG + mocked LLM
- [x] Confidence decomposition assertions (cross-domain bonus > same-domain bonus; contradiction_penalty subtracts)
- [x] Schema strict mode drops malformed fusion output
- [x] `kg.addSynthesis` upsert preserves original id; lower-confidence writes don't overwrite
- [x] `getSynthesesForNode` returns records from both reinforcing and contradicting sides
- [x] Graceful degradation when LLM returns unparseable text
- [x] Regression: insight-engine.js / hypothesis-tester.js tests still pass (they read from the same `kg.user.syntheses`-adjacent `insights` slot; no breakage)

## Deferred (follow-up issues)

- Per-node extraction makes one LLM call per chunk of ~10 nodes. For KGs with 50+ active nodes this is 5+ calls. Could be reduced with topic-clustering before Phase 1, but keeping the simpler shape until we see real cost signal.
- Contradiction detection is deterministic (same-dimension divergent values from disjoint sets). A stronger version would use semantic matching — "compound" vs "compound_with_exceptions" isn't a real contradiction. Out of scope for this PR; add only if we see false-positive contradictions in real data.
- Fusion's domain classification happens twice (Phase 1 LLM tags domains per node, Phase 4 LLM re-tags from the fusion prompt). The Phase 4 tags are what land on the output. This is fine for now but could be unified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)