### PR TITLE
docs: document trait synthesis, salience, and churn patterns (PRs #48/#50/#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — L2 trait synthesis, salience-based inference, churn patterns
+
+- **`Marble.synthesize(opts)`** — new public method that runs L2 trait synthesis
+  end-to-end: per-node trait extraction, cross-domain replication grouping,
+  contradiction detection, and a small K-way emergent-fusion pass. Results
+  persist to `kg.user.syntheses[]`. Designed to run after `learn()` +
+  `investigate()` so it has the full multi-layer KG to work with.
+
+- **`Marble.rebuild()`** — cheap deterministic pass: runs the churn scan
+  (slots reassigned ≥3 times in 180d emit `origin: "churn_pattern"`
+  syntheses), persists results, returns a salience-distribution diagnostic
+  useful for "is this KG signal or ingestion noise?" triage.
+
+- **Five synthesis origin types** now surface in `kg.user.syntheses`:
+  `single_node`, `trait_replication`, `contradiction`, `emergent_fusion`,
+  `churn_pattern`. Each synthesis decomposes into structured fields
+  downstream tools consume as predicates — `trait {dimension, value, weight}`,
+  `mechanics`, `reinforcing_nodes`, `contradicting_nodes`, `domains_bridged`,
+  `confidence_components`, `affinities`, `aversions`, `predictions`,
+  `surprising`. Labels are human handles; the structured fields are the
+  payload.
+
+- **Salience as a first-class KG primitive** (`core/salience.js`). Formula:
+  `0.6 × effective_strength + 0.2 × evidence_norm + 0.2 × slot_volatility`,
+  with a stale-active guardrail that halves effective strength for facts
+  with `valid_to=null` but `evidence_count=1` AND age > 180d. Prevents old
+  one-off beliefs ("user builds X") from dominating top-salient a year
+  after the user moved on.
+
+- **New `KnowledgeGraph` methods:**
+  - `kg.getTopSalient({ types, limit, domains, asOf })` — top-K ranked
+    input source for any pairwise/quadratic pass. Returns annotated nodes
+    with salience / effective_strength / slot_volatility / stale_active.
+  - `kg.salienceDistribution()` — counts, percentiles, stale-active counts,
+    top-10 examples. Diagnostic, no side effects.
+  - `kg.addSynthesis()` — upserts on `(origin, trait.dim, trait.val)`.
+    Lower-confidence writes do not overwrite existing records.
+  - `kg.getSyntheses({ origin, minConfidence, surprising, trait, domainsIncludes })` —
+    filter with any combination.
+  - `kg.getSynthesesForNode(nodeRef)` — returns records where the node
+    appears in either `reinforcing_nodes` or `contradicting_nodes`.
+
+- **`kg.user.insights[]` is now a persistent slot.** Previously `learn()`
+  generated L1.5 insights but dropped them on the floor. They now land in
+  the KG and L2 reuses them as seeds (see "Fixed" below).
+
+- **`InferenceEngine` accepts `opts.seeds`** — skips re-running the L1.5
+  swarm when the caller (e.g. `learn()`) has already computed insights.
+  Eliminates a duplicate LLM pass and a second failure surface.
+
+### Changed — InferenceEngine refactor (fixes OOM on real-sized KGs)
+
+- **Deleted** `_inferFromBelief`, `_inferFromPreferenceIdentity`, and
+  `_inferFromConfidenceGaps` from `InferenceEngine`. On a real KG (thousands
+  of beliefs/prefs/identities) these allocated ~10M-15M template-string
+  candidates before the filter ran, OOM'ing Node with a ~25-50GB peak heap.
+  The output was also pure template noise — no semantic content downstream
+  could use. Cross-L1 pattern discovery now lives entirely in
+  `runTraitSynthesis()`, which is LLM-directed and bounded.
+- **Kept** `_inferFromTemporalPatterns` — genuinely linear and produces
+  unique signal (stale-belief detection, evolving-preference detection).
+  Now reads from `kg.getTopSalient({ limit: 100 })` instead of unbounded
+  `getMemoryNodesSummary()`.
+- **Inline gate in `InferenceEngine.run()`**: sub-threshold candidates are
+  no longer allocated in the first place, only to be filtered at the end.
+
+### Fixed
+
+- **L1.5 insights were not persisted**: `learn()` generated them via
+  `runInsightSwarm()` but never wrote them to `kg.user.insights`, so
+  consumers that read the slot (e.g. `insight-engine.js`,
+  `hypothesis-tester.js`) got nothing. Fixed by writing after the swarm
+  runs.
+- **`InferenceEngine` re-invoked the L1.5 swarm** via `getL2Seeds()` even
+  though `learn()` had just run it 10 lines earlier. Root cause of the
+  "InsightSwarm ran fine but InferenceEngine still fails" class of errors —
+  the duplicate call would trip on transient provider failures. Fixed by
+  threading `seeds` through from `learn()` into the engine.
+- **Silent data loss on L1.5 seeds**: `inference-engine.js` read
+  `seed.implications`, but swarm output has no such field — the intended
+  source is `seed.derived_predictions`. `second_order_effects` was always
+  `[]` for L1.5-seeded candidates until this fix.
+
 ### Added — API surface polish (OOTB integration pass 4)
 
 - **New `Marble#score(items, context)` public method.** Returns every scored

--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ await marble.feedbackBatch([
 // Run the deep learning pipeline (L1.5 insight swarm → L2 inference → L3 clone evolution)
 const stats = await marble.learn();
 // { insights: 7, candidates: 4, clones: 12 }
+
+// (Optional) L2 trait synthesis — derives structured traits with replication,
+// contradiction, and emergent-fusion origins. Persists to kg.user.syntheses[].
+await marble.synthesize();
+
+// (Optional) Churn scan + salience diagnostic. Detects "serial pivoter"-style
+// traits that live in the time series of belief invalidations, and reports
+// how many of the KG's nodes are stale-active one-offs.
+const { churnSyntheses, distribution } = await marble.rebuild();
 ```
 
 > **`learn()` is required for the "Day 2 > Day 1" progressive improvement claim.**
@@ -149,6 +158,11 @@ const stats = await marble.learn();
 > `learn()`. A typical integration calls `learn()` after every N reactions
 > (e.g. N=10) or on a daily schedule. Without it, ranking relies on interest
 > aggregation alone and will not show clone-driven improvements over time.
+>
+> **`synthesize()` and `rebuild()` are optional** and run on their own schedule —
+> `synthesize()` is LLM-heavy (per-node trait extraction) so daily/weekly is
+> typical; `rebuild()` is cheap and deterministic, safe to run on every
+> `learn()` or on a cron.
 
 **Run tests:**
 
@@ -164,6 +178,8 @@ cd marble && npm install && npm test
 - **Three modes** — Score (fast), Swarm (rich), WorldSim (B2B PMF)
 - **Implicit learning** — Learns from dwell time, scroll depth, forwards, silence
 - **Insight-driven KG** — Reasons about WHY, not just WHAT (see [docs/insight-kg.md](docs/insight-kg.md))
+- **Trait synthesis** — Structured cross-domain traits with five origin types (`single_node`, `trait_replication`, `contradiction`, `emergent_fusion`, `churn_pattern`) — downstream tools match against `traits` / `affinities` / `aversions` as predicates, not prose labels
+- **Salience-aware** — `getTopSalient()` filters for important nodes before any pairwise pass; stale one-off facts fade automatically; churn scan surfaces "serial pivoter" traits that live in the time series of invalidations
 - **Relationship-aware** — Models the people in a user's life to improve recommendations
 - **Narrative arc** — Stories sequenced for flow, not just ranked by score
 
@@ -186,8 +202,18 @@ cd marble && npm install && npm test
 │  Telegram, Email, JSON API, Webhook, Video         │
 ├──────────────────────────────────────────────────┤
 │  5. LEARN                                         │
-│  Implicit signals → KG updates → Clone evolution   │
-│  → Better predictions daily                        │
+│  L1.5 Insight Swarm (7 psychological lenses)       │
+│  → L2 Inference + Temporal Patterns                │
+│  → L3 Clone Evolution (kill bottom 20%, mutate)    │
+├──────────────────────────────────────────────────┤
+│  6. SYNTHESIZE (optional, LLM-heavy)              │
+│  Trait extraction → Replication grouping           │
+│  → Contradiction detection → K-way fusion          │
+│  → kg.user.syntheses[] (5 origin types)            │
+├──────────────────────────────────────────────────┤
+│  7. REBUILD (optional, deterministic)             │
+│  Churn scan (slots reassigned ≥3× in 180d)         │
+│  + Salience distribution diagnostic                │
 └──────────────────────────────────────────────────┘
 ```
 
@@ -229,18 +255,24 @@ Five agents, each asking a different question:
 
 ```
 marble/
-├── core/                 # The engine (standalone)
-│   ├── index.js         # Main Marble class — select(), react(), save()
-│   ├── kg.js            # Insight-driven knowledge graph (v2)
-│   ├── scorer.js        # magic_score computation
-│   ├── swarm.js         # Multi-agent curation (5 lenses)
-│   ├── clone.js         # Digital twin — user snapshot for simulation
-│   ├── evolution.js     # Clone population evolution
-│   ├── signals.js       # Implicit signal detection
-│   ├── arc.js           # Narrative arc reranking (10 slots)
-│   ├── decay.js         # Exponential decay (14-day half-life)
-│   ├── embeddings.js    # Local ONNX embeddings (384-dim)
-│   └── types.js         # Type definitions, weights
+├── core/                   # The engine (standalone)
+│   ├── index.js           # Main Marble class — select/react/learn/synthesize/rebuild
+│   ├── kg.js              # Insight-driven knowledge graph (v2)
+│   ├── scorer.js          # magic_score computation
+│   ├── swarm.js           # Multi-agent curation (5 lenses)
+│   ├── insight-swarm.js   # L1.5 psychological probe committee (7 lenses)
+│   ├── inference-engine.js# L2 inference: L1.5 passthrough + temporal patterns
+│   ├── trait-synthesis.js # L2 trait synthesis (4 origins) — per-node extraction,
+│   │                      # replication, contradiction, K-way fusion
+│   ├── salience.js        # Salience scoring + churn scan (5th origin:
+│   │                      # churn_pattern) + getTopSalient/salienceDistribution
+│   ├── clone.js           # Digital twin — user snapshot for simulation
+│   ├── evolution.js       # Clone population evolution
+│   ├── signals.js         # Implicit signal detection
+│   ├── arc.js             # Narrative arc reranking (10 slots)
+│   ├── decay.js           # Exponential decay (14-day half-life)
+│   ├── embeddings.js      # Local ONNX embeddings (384-dim)
+│   └── types.js           # Type definitions, weights
 │
 ├── web/                 # Web reader + signal tracker + dashboard
 │   ├── reader.js        # Story page (tracks dwell, scroll, clicks)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -100,6 +100,59 @@ Persist KG state to disk.
 await marble.save();
 ```
 
+### `marble.synthesize(opts) → Synthesis[]`
+
+Run **L2 trait synthesis**. Derives structured psychological/behavioral traits from individual facts, then checks across the full KG whether each trait **replicates** across domains (confidence up), gets **contradicted** (surface as first-class gap), or only appears in a **K-way emergent fusion**. Persists results to `kg.user.syntheses[]` and returns the stored records.
+
+Designed to run after `learn()` + `investigate()` so the full multi-layer KG is available as raw material.
+
+**Options** (all optional — see `core/trait-synthesis.js` for full list):
+
+| Option | Default | Purpose |
+|---|---|---|
+| `perNodeExtraction` | `true` | Phase 1 per-node trait extraction |
+| `extractionChunkSize` | `10` | Nodes per LLM call in Phase 1 |
+| `fusionSamples` | `5` | Number of K-way emergent-fusion samples |
+| `k` | `10` | Nodes per fusion sample |
+| `contradictionScan` | `true` | Phase 3 contradiction detection |
+| `domainSpread` | `true` | Enforce domain diversity in fusion samples |
+| `strengthRange` | `[0.4, 0.9]` | Skip obvious + near-dead nodes |
+| `alpha` | `0.15` | Replication-bonus coefficient |
+| `beta` | `1.3` | Cross-domain multiplier |
+| `gamma` | `0.2` | Contradiction-penalty coefficient |
+| `requireSurprising` | `false` | Drop syntheses not flagged surprising |
+| `minConfidence` | `0.4` | Drop below threshold |
+| `schemaStrict` | `true` | Drop on any required field missing |
+
+```javascript
+const syntheses = await marble.synthesize();
+// [{ origin: 'trait_replication', trait: { dimension, value, weight }, confidence, ... }, ...]
+
+// Filter by origin after the run
+const contradictions = marble.kg.getSyntheses({ origin: 'contradiction' });
+```
+
+### `marble.rebuild() → { churnSyntheses, distribution }`
+
+Cheap deterministic pass — no LLM calls. Runs the **churn scan** (slots reassigned ≥3 times in 180d emit `origin: "churn_pattern"` syntheses) and returns the **salience distribution** (counts, percentiles, stale-active counts, top-10 examples) for triage.
+
+Safe to run on every `learn()` or on a cron. The churn scan captures "serial pivoter"-style traits that live in the time series of belief invalidations, not the current snapshot.
+
+```javascript
+const { churnSyntheses, distribution } = await marble.rebuild();
+
+console.log(distribution);
+// {
+//   total: 4509,
+//   staleActive: 2837,     // one-off facts older than 180d — likely ingestion noise
+//   percentiles: { p10, p50, p90, p99, max },
+//   byType: { belief: {...}, preference: {...}, identity: {...} },
+//   topExamples: [{ ref: 'belief:running', salience: 0.82, ... }, ...]
+// }
+```
+
+Use `distribution.staleActive / distribution.total` as a quick "is this KG mostly signal or mostly ingestion noise?" check. A high ratio (>50%) suggests an ingest-dedup follow-up is warranted.
+
 ---
 
 ## Profile Creation
@@ -458,6 +511,98 @@ Returns source credibility score (0–1). Defaults to 0.5 for unknown sources.
 
 Check if user has already seen a story.
 
+### `kg.getTopSalient(opts) → Annotated[]`
+
+Return the top-K most salient nodes across the requested L1 types. **Use this instead of unbounded accessors as the input to any pairwise or quadratic inference pass** — guarantees the pass runs in bounded memory regardless of KG size.
+
+Salience folds `effective_strength` (strength × recency decay) with `evidence_norm` and `slot_volatility`, applies the stale-active guardrail, and returns a ranked list.
+
+**Formula:**
+
+```
+salience = 0.6 × effective_strength + 0.2 × evidence_norm + 0.2 × slot_volatility
+```
+
+- `effective_strength` — `strength × 2^(-age_days / halfLife)`, halved when `valid_to=null` + `evidence_count=1` + age > 180d (stale-active guardrail)
+- `evidence_norm` — `log(1 + evidence_count) / log(10)`, so 10× reinforcement ≈ 1.0
+- `slot_volatility` — invalidations on this slot in the last 180d, normalized to 0-1
+
+**Options:**
+
+| Option | Default | Purpose |
+|---|---|---|
+| `types` | `['belief', 'preference', 'identity']` | Which L1 types to rank |
+| `limit` | `100` | Top-K cutoff |
+| `domains` | — | Keep only nodes whose stored `domain` matches |
+| `asOf` | — | ISO date for as-of queries |
+
+```javascript
+const top = kg.getTopSalient({ types: ['belief'], limit: 50 });
+// [
+//   {
+//     node: { topic: 'running', claim: '...', strength: 0.85, ... },
+//     type: 'belief',
+//     ref: 'belief:running',
+//     salience: 0.82,
+//     effective_strength: 0.75,
+//     slot_volatility: 0.0,
+//     stale_active: false
+//   },
+//   ...
+// ]
+```
+
+### `kg.salienceDistribution(opts) → Distribution`
+
+Diagnostic. Returns counts, percentiles, stale-active counts, byType breakdown, and the top-10 most salient nodes. Pure function, no side effects.
+
+```javascript
+const d = kg.salienceDistribution();
+// {
+//   total: 4509,
+//   staleActive: 2837,
+//   percentiles: { p10, p50, p90, p99, max },
+//   byType: { belief: { count, staleActive }, preference: {...}, identity: {...} },
+//   topExamples: [{ ref, salience, effective_strength, slot_volatility, stale_active }, ...]
+// }
+```
+
+### `kg.addSynthesis(synthesis) → Synthesis`
+
+Persist a synthesis record. Generates an `id` + `generated_at` if missing. **Upserts on `(origin, trait.dimension, trait.value)`** — a re-run of `synthesize()` doesn't duplicate the same pattern; the higher-confidence record wins while keeping the original id.
+
+### `kg.getSyntheses(opts) → Synthesis[]`
+
+Filter syntheses with any combination of these:
+
+| Option | Type | Purpose |
+|---|---|---|
+| `minConfidence` | number | Drop below threshold |
+| `origin` | string | `'single_node'` / `'trait_replication'` / `'contradiction'` / `'emergent_fusion'` / `'churn_pattern'` |
+| `surprising` | boolean | Only records flagged surprising |
+| `trait` | `{ dimension, value }` | Both optional — match on whichever provided |
+| `domainsIncludes` | string[] | Keep records whose `domains_bridged` covers ALL given domains |
+
+```javascript
+// Aspirational-vs-actual gaps — the most valuable signal for content systems
+const gaps = kg.getSyntheses({ origin: 'contradiction' });
+
+// High-confidence cross-domain traits
+const strong = kg.getSyntheses({ minConfidence: 0.7, origin: 'trait_replication' });
+
+// Serial-pivoter patterns
+const churn = kg.getSyntheses({ origin: 'churn_pattern' });
+```
+
+### `kg.getSynthesesForNode(nodeRef) → Synthesis[]`
+
+Return records where the node appears in **either** `reinforcing_nodes` or `contradicting_nodes`. Useful for "what patterns does this fact support or undermine?" queries.
+
+```javascript
+// What does "user runs 6x/week" imply across the KG?
+const patterns = kg.getSynthesesForNode('belief:running');
+```
+
 ---
 
 ## HTTP Endpoints
@@ -657,6 +802,53 @@ Check all KPIs against targets, return any violations.
   published_at: '2026-03-25T10:00:00Z',
   valence: 0.8,        // optional: positive/negative sentiment
   actionability: 0.7   // optional: pre-computed actionability
+}
+```
+
+### Synthesis (from `marble.synthesize()` / `kg.user.syntheses[]`)
+
+Output of L2 trait synthesis — structured enough that downstream tools can reason over `trait` / `affinities` / `aversions` as predicates, not free-form prose.
+
+```javascript
+{
+  id: 'synth_1729..._abc123',
+  label: 'Replicated across 3 domains — time orientation: compound',  // HUMAN handle, not the payload
+  origin: 'trait_replication',  // 'single_node' | 'trait_replication' | 'contradiction' | 'emergent_fusion' | 'churn_pattern'
+
+  // The trait itself — matchable unit for downstream predicate matching
+  trait: {
+    dimension: 'time_orientation',
+    value: 'compound',
+    weight: 0.85
+  },
+
+  // Why this pattern coheres — shown to users as the "why we recommended this"
+  mechanics: 'Marathon training, a 3-yr daily prayer practice, 5-yr company horizons, and 5+ yr stock positions all independently imply comfort with long feedback cycles and unglamorous repetition.',
+
+  // Full provenance — every synthesis traces back to its source facts
+  reinforcing_nodes:    ['belief:running', 'identity:daily_prayer', 'context:5yr_ventures', 'preference:long_holds'],
+  contradicting_nodes: [],  // contradiction case only — facts that undermine the trait
+  domains_bridged:     ['health', 'spirituality', 'work', 'finance'],
+  isolated:             false,
+
+  // Confidence decomposed so downstream can requery at different thresholds
+  confidence: 0.88,
+  confidence_components: {
+    base_from_llm:         0.65,
+    replication_bonus:     0.25,
+    contradiction_penalty: 0.0,
+    cross_domain:          true
+  },
+
+  // What downstream SHOULD surface + MUST deprioritize
+  affinities:  ['long-form essays on compound practice', 'marathon psychology × stoicism crossovers', ...],
+  aversions:   ['hustle porn / 4am grind content', 'viral-in-90-days narratives', ...],
+  predictions: ['Will dwell >2× average on content framing work as endurance sport', ...],  // falsifiable, feedback-loop input
+
+  surprising:  false,   // LLM-flagged; useful for ranking
+  generated_at: '2026-04-22T...',
+  model:        'claude-opus-4-6',
+  mode:         'trait_synthesis'   // or 'fusion' | 'churn_scan'
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,7 +193,126 @@ User reacts to item
 - Long-term preference learning
 - Model stability maintenance
 
+### 7. Salience Engine (`salience.js`)
+**Responsibility**: Top-K filtering and churn detection — the primitive that replaces unbounded "scan everything" passes
+
+```javascript
+// Public API, also exposed on KnowledgeGraph
+import {
+  computeSalience,           // score a single node
+  computeVolatility,          // Map<slotKey, {score, invalidations, records}>
+  getTopSalient,              // ranked list across types
+  salienceDistribution,       // diagnostic: counts, percentiles, stale-active
+  runChurnScan,               // deterministic → churn_pattern syntheses
+} from 'marble/core/salience.js';
+```
+
+**Formula:**
+
+```
+salience = 0.6 × effective_strength + 0.2 × evidence_norm + 0.2 × slot_volatility
+```
+
+- **`effective_strength`** — `strength × 2^(-age_days / halfLife)`, halved when `valid_to=null` + `evidence_count=1` + age > 180d (stale-active guardrail prevents old one-off facts from dominating)
+- **`evidence_norm`** — `log(1 + evidence_count) / log(10)` — 10× reinforcement normalizes to ~1.0
+- **`slot_volatility`** — invalidations on this slot in trailing 180d, normalized to 0-1; high volatility is itself a signal (e.g. "serial project pivoter")
+
+`getTopSalient({ types, limit, domains })` is the input source for any pairwise / quadratic inference pass. Working with this instead of raw `getMemoryNodesSummary()` keeps the pass bounded regardless of KG size — a 5000-node KG that previously OOM'd now runs in 62ms.
+
+The churn scan (`runChurnScan`) emits **`origin: "churn_pattern"`** syntheses for slots reassigned ≥3 times in 180d. Deterministic, no LLM. Captures traits that live in the time series (e.g. "user serial-pivots projects") — invisible to snapshot-based inference.
+
+### 8. Trait Synthesis (`trait-synthesis.js`)
+**Responsibility**: LLM-directed cross-L1 pattern discovery — replaces the old O(N²) pairwise generators
+
+```javascript
+import { runTraitSynthesis } from 'marble/core/trait-synthesis.js';
+const syntheses = await runTraitSynthesis(kg, { llmClient, ...opts });
+```
+
+Four phases, run in sequence:
+
+```
+Phase 1  Per-node trait extraction (LLM, chunks of ~10 nodes)
+           each fact → 1-3 traits { dimension, value, weight, confidence, evidence_quote, domain }
+
+Phase 2  Replication grouping (in-process, no LLM)
+           group candidates by (dimension, value), compute replication_bonus
+           cross-domain multiplier rewards traits that span multiple life areas
+
+Phase 3  Contradiction detection (in-process, no LLM)
+           same dimension + divergent values from DISJOINT node sets → "contradiction" origin
+           first-class aspirational-vs-actual gap recording
+
+Phase 4  K-way emergent fusion (LLM, small number of domain-spread samples)
+           gestalt patterns that no single-node extraction would surface
+           LLM returns {label: null} if facts don't cohere — no inventing
+```
+
+Output syntheses carry structured fields (`trait`, `mechanics`, `reinforcing_nodes`, `contradicting_nodes`, `domains_bridged`, `confidence_components`, `affinities`, `aversions`, `predictions`). Labels are human handles; the structured fields are what downstream tools match against.
+
+### 9. Insight Swarm (`insight-swarm.js`)
+**Responsibility**: L1.5 — 7 psychological-dimension agents probe the KG for questions worth asking
+
+- Dimensions: desires, fears, motivations, frustrations, dreams, identity tensions, avoidance patterns
+- Each agent generates 3-5 probing questions grounded in specific KG data
+- Output persists to `kg.user.insights[]` and flows into `InferenceEngine.run()` as pre-built seeds (see `opts.seeds`) — avoids re-running the swarm
+
+### 10. Inference Engine (`inference-engine.js`)
+**Responsibility**: L2 — gates L1.5 passthrough candidates and runs temporal pattern detection
+
+Post-refactor (April 2026) this is a thin layer. The old `_inferFromBelief` / `_inferFromPreferenceIdentity` / `_inferFromConfidenceGaps` methods were deleted — they emitted O(N²) template-string noise that OOM'd on real-sized KGs. Cross-L1 pattern discovery lives entirely in `trait-synthesis.js` now.
+
+```javascript
+async run() {
+  // L1.5 passthrough — use caller-supplied seeds when available
+  // Temporal patterns — input capped via kg.getTopSalient({ limit: 100 })
+  // Inline gate — sub-threshold candidates never allocated
+}
+
+async runTraitSynthesis(opts)  // thin delegation into trait-synthesis.js
+```
+
 ## Data Flow
+
+### 0. Reasoning Pipeline (learn → synthesize → rebuild)
+
+```
+marble.learn()
+    │
+    ├──▶ L1.5 InsightSwarm          (7 psychological lenses, committee of agents)
+    │       └──▶ kg.user.insights[]        (persistent; reused as L2 seeds)
+    │
+    ├──▶ L2 InferenceEngine.run()
+    │       ├──▶ L1.5 passthrough candidates (inline gate; no alloc below threshold)
+    │       └──▶ _inferFromTemporalPatterns (input = kg.getTopSalient({limit:100}))
+    │
+    └──▶ L3 Clone evolution          (kill bottom 20%, mutate survivors)
+
+marble.synthesize()          [LLM-heavy; daily/weekly]
+    │
+    └──▶ runTraitSynthesis()         (4 phases)
+          ├──▶ Phase 1: per-node trait extraction
+          ├──▶ Phase 2: replication grouping → trait_replication / single_node
+          ├──▶ Phase 3: contradiction detection → contradiction
+          └──▶ Phase 4: K-way fusion → emergent_fusion
+               │
+               └──▶ kg.user.syntheses[] via kg.addSynthesis() (upsert)
+
+marble.rebuild()             [deterministic; safe to run per-learn or on cron]
+    │
+    ├──▶ runChurnScan()               → churn_pattern origin → kg.addSynthesis()
+    └──▶ salienceDistribution()       → diagnostic { total, staleActive, percentiles, ... }
+```
+
+**5 synthesis origins** — downstream tools can filter on any of them:
+
+| Origin | Source | Example |
+|---|---|---|
+| `single_node` | trait implied by exactly one node | "Isolated signal — risk profile: high volatility tolerant" |
+| `trait_replication` | same trait implied by multiple nodes across domains | "Replicated across 3 domains — time orientation: compound" |
+| `contradiction` | same dimension, divergent values from disjoint node sets | "Conflicting signals on follow_through: sustained ↔ inconsistent" |
+| `emergent_fusion` | gestalt pattern from K-way sample | "Endurance-engineered founder practice" |
+| `churn_pattern` | slot reassigned ≥3 times in 180d | "Churn on belief current_project" — "serial_pivoter" |
 
 ### 1. Story Ingestion
 ```

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -109,6 +109,47 @@ Every cycle (daily by default):
 
 After ~2 weeks, surviving clones have converged on the user's actual preferences — including latent interests they never explicitly stated.
 
+### Step 9: Trait Synthesis (Optional, LLM-heavy)
+
+`marble.synthesize()` derives **structured traits** from the KG — not just "what topics does the user like" but "what psychological/behavioral dimensions replicate across their life." It runs in four phases:
+
+**Phase 1 — Per-node trait extraction.** Each L1 fact ("runs 6×/week on Higdon program") gets 1-3 traits extracted: `{ dimension: "time_orientation", value: "compound", weight: 0.75, evidence_quote: "long runs" }`. Uses the LLM in small batches (~10 nodes per call).
+
+**Phase 2 — Replication grouping.** The same trait showing up independently from several nodes is much stronger evidence than one node. Cross-domain replication (running + prayer + long stock holds → `time_orientation: compound` across health + spirituality + finance) gets a multiplier.
+
+**Phase 3 — Contradiction detection.** Same dimension with divergent values from **disjoint** node sets surfaces as a first-class `origin: "contradiction"` record — the aspirational-vs-actual gap. Example: "follow_through" implies `sustained` from daily practices but `inconsistent` from job-hop history. Both sides get recorded with full provenance.
+
+**Phase 4 — K-way emergent fusion.** A small number of domain-spread samples asking the LLM "find a gestalt pattern across these K facts, or return null if they don't cohere." Captures patterns no single-node extraction would surface ("endurance-engineered founder practice").
+
+Every synthesis decomposes into structured fields downstream tools consume as predicates — not prose labels:
+
+- `trait: { dimension, value, weight }` — the matchable unit
+- `mechanics` — why this pattern coheres (shown to users as "why we recommended this")
+- `reinforcing_nodes` / `contradicting_nodes` — full provenance, both sides
+- `confidence_components` — `base_from_llm` / `replication_bonus` / `contradiction_penalty` / `cross_domain`
+- `affinities` / `aversions` — specific enough to match real content titles
+- `predictions` — falsifiable (observable dwell / share / skip)
+
+### Step 10: Rebuild (Optional, Deterministic)
+
+`marble.rebuild()` runs two cheap deterministic passes — no LLM:
+
+1. **Churn scan.** Slots (e.g. `belief:current_project`) reassigned ≥3 times in 180d emit `origin: "churn_pattern"` syntheses. This is what captures "serial pivoter" traits — patterns that live in the TIME SERIES of invalidations, not the current snapshot. Event-driven inference never sees this; `rebuild()` does.
+
+2. **Salience distribution diagnostic.** Returns percentiles, stale-active counts, and top-10 examples so you can quickly answer "is this KG mostly signal or mostly ingestion noise?" Use `distribution.staleActive / distribution.total` as the triage ratio.
+
+## Synthesis Origins (the 5 kinds of pattern)
+
+Every synthesis has one of five `origin` values — downstream can filter by origin to, e.g., surface aspirational-vs-actual gaps separately from coherent traits:
+
+| Origin | Where it comes from | What it means |
+|---|---|---|
+| `single_node` | One fact implies a trait (Phase 1 only) | Low-confidence isolated signal — moderate weight, flagged `isolated: true` |
+| `trait_replication` | Same trait from ≥2 nodes, optionally cross-domain | High confidence. The "endurance discipline across health + work + finance" case |
+| `contradiction` | Same dimension, divergent values from disjoint nodes | The aspirational-vs-actual gap. Highest-leverage signal for content systems |
+| `emergent_fusion` | K-way LLM gestalt pattern | The "no single fact reveals this" case. Carries a full `mechanics` explanation |
+| `churn_pattern` | Slot reassigned ≥3 times in 180d | "Serial pivoter" trait. Lives in the time series, not the snapshot. Emitted by `rebuild()` |
+
 ## The Pipeline (Visual)
 
 ```
@@ -140,8 +181,22 @@ After ~2 weeks, surviving clones have converged on the user's actual preferences
 │  Telegram | Email | JSON API | Webhook | Video           │
 ├─────────────────────────────────────────────────────────┤
 │  5. LEARN                                                │
-│  World signals + platform signals + web reader signals   │
-│  → Clone evolution: surviving variants improve daily     │
+│  L1.5 InsightSwarm (7 psychological lenses, persistent)  │
+│  → L2 InferenceEngine (L1.5 passthrough + temporal)      │
+│  → L3 Clone evolution (kill bottom 20%, mutate survivors)│
+├─────────────────────────────────────────────────────────┤
+│  6. SYNTHESIZE (optional, LLM-heavy)                     │
+│  Phase 1: Per-node trait extraction                      │
+│  Phase 2: Replication grouping (cross-domain bonus)      │
+│  Phase 3: Contradiction detection (disjoint node sets)   │
+│  Phase 4: K-way emergent fusion                          │
+│  → kg.user.syntheses[] (4 origins: single_node,          │
+│    trait_replication, contradiction, emergent_fusion)    │
+├─────────────────────────────────────────────────────────┤
+│  7. REBUILD (optional, deterministic)                    │
+│  Churn scan: slot reassigned ≥3× in 180d                 │
+│  → churn_pattern origin (5th origin)                     │
+│  + salienceDistribution() diagnostic                     │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -158,3 +213,9 @@ After ~2 weeks, surviving clones have converged on the user's actual preferences
 | Convergence time | ~2 weeks |
 | Cost per simulation (with LLM) | $0.12-$0.20 |
 | Cost without LLM | $0 (local embeddings) |
+| Salience formula | `0.6 × effective_strength + 0.2 × evidence_norm + 0.2 × slot_volatility` |
+| Stale-active guardrail | `valid_to=null` + `evidence_count=1` + age > 180d → effective strength × 0.5 |
+| Volatility window | 180 days (slot invalidations) |
+| Churn threshold | ≥3 invalidations in window → `churn_pattern` synthesis |
+| Synthesis fusion samples | 5 K-way samples per `synthesize()` run (K ≈ 10 nodes) |
+| L1.5 → L2 seed reuse | `learn()` passes insights into `InferenceEngine` as `opts.seeds` — no duplicate LLM call |

--- a/docs/insight-kg.md
+++ b/docs/insight-kg.md
@@ -168,6 +168,96 @@ The KG auto-migrates from v1 (flat interests) to v2 (insights) on load:
 
 The `getInterests()` method still works for v1-style access.
 
+## Trait Synthesis Layer (L2)
+
+Beyond insights and hypotheses, Marble's L2 **trait synthesis** layer derives structured psychological/behavioral traits from the KG and persists them as `kg.user.syntheses[]`. This is a separate layer from insights — it runs via `marble.synthesize()` (LLM-heavy) and `marble.rebuild()` (deterministic, cheap).
+
+### Synthesis structure
+
+```javascript
+{
+  id: 'synth_1729..._abc',
+  label: 'Replicated across 3 domains — time orientation: compound',  // HUMAN handle
+  origin: 'trait_replication',
+
+  // The matchable unit — downstream reasons over these, not the label
+  trait: { dimension: 'time_orientation', value: 'compound', weight: 0.85 },
+
+  // Why this pattern coheres — shown to users as the "why"
+  mechanics: 'Marathon training, daily prayer, 5-yr company horizons, and long stock holds all imply comfort with delayed feedback.',
+
+  // Provenance — both sides
+  reinforcing_nodes:   ['belief:running', 'identity:daily_prayer', 'context:5yr_ventures', 'preference:long_holds'],
+  contradicting_nodes: [],
+  domains_bridged:     ['health', 'spirituality', 'work', 'finance'],
+
+  // Confidence decomposition — requeryable at different thresholds
+  confidence: 0.88,
+  confidence_components: {
+    base_from_llm: 0.65, replication_bonus: 0.25, contradiction_penalty: 0.0, cross_domain: true
+  },
+
+  // Actionable predicates — specific enough to match real content
+  affinities:  ['long-form essays on compound practice', 'marathon psychology × stoicism crossovers'],
+  aversions:   ['hustle porn', 'viral-in-90-days narratives'],
+  predictions: ['Will dwell >2× average on content framing work as endurance sport'],  // falsifiable
+
+  surprising: false,
+  generated_at: '2026-04-22T...',
+  mode: 'trait_synthesis'
+}
+```
+
+### Five origin types
+
+| Origin | Source | Confidence signal |
+|---|---|---|
+| `single_node` | Trait implied by exactly ONE node (Phase 1 only) | Low — `isolated: true`; one data point |
+| `trait_replication` | Same trait implied by MULTIPLE nodes, optionally cross-domain | High — `replication_bonus` × `cross_domain` multiplier |
+| `contradiction` | Same dimension, DIVERGENT values from disjoint node sets | `contradiction_penalty` applied; `surprising: true` — aspirational-vs-actual gap |
+| `emergent_fusion` | Gestalt pattern from K-way cross-domain sample | LLM-stated confidence; patterns no single-node extraction would surface |
+| `churn_pattern` | Slot reassigned ≥3 times in 180d (deterministic, no LLM) | Scales with invalidation count; emitted by `rebuild()` not `synthesize()` |
+
+### How it relates to insights
+
+`kg.user.insights[]` and `kg.user.syntheses[]` are separate slots:
+
+- **`insights`** — L1.5 InsightSwarm output. Each insight is a probing question against one psychological lens (fears, desires, etc.). Persistent since PR #48; consumed as L2 seeds.
+- **`syntheses`** — L2 trait synthesis output. Each synthesis is a structured trait with evidence, contradiction awareness, and matchable predicates. Consumed by downstream tools (recommenders, briefers) as the WHY behind every ranking.
+
+Insights are *questions worth asking the user*. Syntheses are *traits derivable from what the user has already done*.
+
+## Churn Patterns & Salience
+
+Not every trait lives in the current snapshot of the KG. The fact that a user has **reassigned** a slot many times is itself a trait — "serial pivoter" is a real psychological signal that cannot be seen by examining only the active beliefs.
+
+`marble.rebuild()` runs a churn scan (deterministic, no LLM) that counts invalidations per slot in a trailing window and emits `origin: "churn_pattern"` syntheses when the count crosses a threshold:
+
+```javascript
+{
+  origin: 'churn_pattern',
+  label: 'Churn on belief "current_project"',
+  trait: { dimension: 'stability_belief', value: 'serial_pivoter', weight: 1.0 },
+  mechanics: 'The belief slot "current_project" has been reassigned 4 times in the past 180 days. This pattern itself is a trait: the user cycles through states on this slot rather than settling. Downstream tools should weight the CURRENT value of this slot less and treat the churn as the stable signal.',
+  reinforcing_nodes: [/* all historical records on the slot */],
+  predictions: ['The current value on slot "current_project" will be reassigned again within 180d.'],
+  surprising: true,
+  mode: 'churn_scan'
+}
+```
+
+### Salience as the filter primitive
+
+Before any pairwise/quadratic pass, use `kg.getTopSalient({ types, limit })` — **never read the raw `getMemoryNodesSummary()` into a quadratic loop** on a real-sized KG.
+
+```
+salience = 0.6 × effective_strength + 0.2 × evidence_norm + 0.2 × slot_volatility
+```
+
+The stale-active guardrail halves `effective_strength` for `valid_to=null` facts that are old AND low-evidence — prevents old one-off beliefs from dominating top-salient a year after the user moved on.
+
+Use `kg.salienceDistribution()` to triage — if `staleActive / total` is high, the KG has accumulated ingestion noise and downstream reasoning will fight through it.
+
 ## Why This Matters
 
 A flat interest tracker tells you: "User likes AI (0.9)."

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -259,6 +259,121 @@ console.log('Prediction accuracy:', report.kpis.prediction_accuracy);
 // { count: 45, average: 0.72, trend: 'improving', status: 'ok' }
 ```
 
+## 13. L2 Trait Synthesis — Structured Traits with Provenance
+
+`marble.synthesize()` runs after `learn()` to extract structured psychological/behavioral traits from the KG. Downstream tools reason over `trait` / `affinities` / `aversions` as predicates, not prose labels.
+
+```javascript
+import { Marble } from 'marble';
+
+const marble = new Marble({
+  storage: `./data/${userId}-kg.json`,
+  llm: async (prompt) => callYourLLM(prompt),
+});
+await marble.init();
+
+// Standard pipeline first
+await marble.learn();
+
+// Then L2 trait synthesis — derives traits from existing L1 + L1.5 state
+const syntheses = await marble.synthesize();
+
+// Five origin types — filter by what you care about
+const replicated    = marble.kg.getSyntheses({ origin: 'trait_replication', minConfidence: 0.7 });
+const contradictions = marble.kg.getSyntheses({ origin: 'contradiction' });
+const fusions        = marble.kg.getSyntheses({ origin: 'emergent_fusion' });
+
+for (const s of replicated) {
+  console.log(`[${s.trait.dimension}=${s.trait.value}] (${s.confidence}) — ${s.label}`);
+  console.log(`  Mechanics: ${s.mechanics}`);
+  console.log(`  Reinforced by: ${s.reinforcing_nodes.join(', ')}`);
+  console.log(`  Affinities: ${s.affinities.slice(0, 3).join(' / ')}`);
+}
+
+// Contradictions are the aspirational-vs-actual gap — often the highest-leverage signal
+for (const c of contradictions) {
+  console.log(`GAP — ${c.label}`);
+  console.log(`  Reinforcing: ${c.reinforcing_nodes.join(', ')}`);
+  console.log(`  Contradicting: ${c.contradicting_nodes.join(', ')}`);
+}
+```
+
+### Matching content against syntheses
+
+Downstream tools (e.g. a content recommender) score items by matching item features against the structured predicates — `label` never enters the scoring:
+
+```javascript
+function scoreAgainstSyntheses(item, kg) {
+  let score = 0;
+  for (const syn of kg.getSyntheses({ minConfidence: 0.6 })) {
+    const posMatch = syn.affinities.some(a => matchesFeature(item, a));
+    const negMatch = syn.aversions.some(a => matchesFeature(item, a));
+    if (posMatch) score += syn.trait.weight * syn.confidence;
+    if (negMatch) score -= syn.trait.weight * syn.confidence;
+  }
+  return score;
+}
+```
+
+## 14. Churn Patterns and Salience Diagnostic — `marble.rebuild()`
+
+`marble.rebuild()` is cheap and deterministic — no LLM calls. It captures patterns that live in the time series of belief invalidations (e.g. "user serial-pivots projects") and returns a salience-distribution diagnostic so you can tell how much of the KG is signal vs. ingestion noise.
+
+```javascript
+const { churnSyntheses, distribution } = await marble.rebuild();
+
+// Churn patterns: slots reassigned ≥3 times in 180d → origin: 'churn_pattern'
+for (const c of churnSyntheses) {
+  console.log(`${c.label} (confidence ${c.confidence})`);
+  console.log(`  ${c.mechanics}`);
+  // "The belief slot current_project has been reassigned 4 times in the past 180 days..."
+}
+
+// Salience distribution — triage the KG
+console.log(`Total active nodes: ${distribution.total}`);
+console.log(`Stale-active (likely noise): ${distribution.staleActive}`);
+console.log(`Noise ratio: ${(distribution.staleActive / distribution.total * 100).toFixed(0)}%`);
+console.log(`Salience percentiles:`, distribution.percentiles);
+console.log(`\nTop 10 most salient:`);
+distribution.topExamples.forEach(n => {
+  console.log(`  ${n.ref}: salience=${n.salience} (eff_strength=${n.effective_strength}, vol=${n.slot_volatility})`);
+});
+```
+
+### Using `kg.getTopSalient()` directly
+
+Any code that does pairwise passes over the KG should use `getTopSalient()` as the input source to stay bounded:
+
+```javascript
+// Bounded input — safe on a 5000-node KG
+const topBeliefs = marble.kg.getTopSalient({ types: ['belief'], limit: 100 });
+
+// Domain-scoped pass
+const healthAndWork = marble.kg.getTopSalient({
+  domains: ['health', 'work'],
+  limit: 50,
+});
+
+for (const { node, salience, stale_active } of topBeliefs) {
+  if (stale_active) continue;  // skip likely-noise entries
+  // ...do work over the salient subset...
+}
+```
+
+### Running both on a schedule
+
+```javascript
+// Typical cadence: learn() per-reaction or every N reactions;
+// synthesize() daily or weekly; rebuild() on every learn() or on a cron.
+async function dailyJob(marble) {
+  await marble.learn();
+  await marble.rebuild();         // cheap, always safe
+  if (isWeeklyDay()) {
+    await marble.synthesize();    // LLM-heavy, schedule accordingly
+  }
+}
+```
+
 ---
 
 ## End-to-End Startup Integration


### PR DESCRIPTION
Full docs sweep covering the three-PR architectural arc that landed on main:
- **[#48](https://github.com/AlexShrestha/marble/pull/48)** — L1.5 insight persistence + L2 seed reuse + derived_predictions fix
- **[#50](https://github.com/AlexShrestha/marble/pull/50)** — L2 trait synthesis with 4 origin types
- **[#51](https://github.com/AlexShrestha/marble/pull/51)** — salience-based inference + 5th origin (churn_pattern) + OOM fix

## Files touched

| File | Net lines | What got added |
|---|---|---|
| \`CHANGELOG.md\` | +83 | Top-of-Unreleased section: added/changed/fixed for all three PRs |
| \`README.md\` | +52 | Quick Start calls, Features bullets, pipeline diagram steps 6+7, core/ listing |
| \`docs/api-reference.md\` | +192 | \`marble.synthesize()\`, \`marble.rebuild()\`, \`kg.getTopSalient()\`, \`kg.salienceDistribution()\`, \`kg.addSynthesis()\`, \`kg.getSyntheses()\`, \`kg.getSynthesesForNode()\`, Synthesis type ref |
| \`docs/architecture.md\` | +119 | Components 7-10 (Salience / Trait Synthesis / InsightSwarm / InferenceEngine), reasoning-pipeline data flow, 5-origin table |
| \`docs/how-it-works.md\` | +65 | Step 9 (Synthesize), Step 10 (Rebuild), 5 origins plain-English table, pipeline visual, Key Numbers |
| \`docs/insight-kg.md\` | +90 | "Trait Synthesis Layer (L2)" + "Churn Patterns & Salience" sections |
| \`docs/usage-examples.md\` | +115 | Example 13 (\`synthesize()\`) + Example 14 (\`rebuild()\` + \`getTopSalient()\`) |

**Total: +708 insertions, -16 deletions.**

## Repo metadata (already applied via gh)

Topics added: \`personalization\`, \`knowledge-graph\`, \`user-modeling\`, \`llm\`, \`recommendation-engine\`, \`trait-synthesis\`, \`content-curation\`, \`ai-agents\`, \`user-simulation\`. Was previously empty. Description unchanged (still accurate).

## Scope note

This PR documents only the NEW features from the three landed PRs. Preexisting stale content in these files (e.g. \`marble.react(storyId, reaction, topics, source)\` in api-reference.md vs. the actual \`marble.react(item, reaction)\` per CHANGELOG) was left as-is to keep this review-able. A follow-up cleanup pass can sweep the older inaccuracies.

## Test plan

- [x] No code changes — docs only
- [x] All markdown renders (no broken codeblocks, tables, or links)
- [x] Headings remain anchorable (no duplicate heading ids introduced)
- [x] Topics visible on GitHub repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)